### PR TITLE
bau-postgres-optimisation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready -d ${{inputs.db_name}} -U postgres -p 5432
+          --health-cmd 'pg_isready -d ${{inputs.db_name}} -U postgres -p 5432'
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,15 +98,15 @@ jobs:
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: ${{inputs.db_name}}
+          POSTGRES_DATABASE: ${{inputs.db_name}}
           POSTGRESQL_FSYNC: 'off'
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 8s
+          --health-timeout 2s
+          --health-retries 10
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,8 +103,8 @@ jobs:
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd "pg_isready --username=postgres"
-          --health-interval 12s
+          --health-cmd pg_isready -d ${{inputs.db_name}} -U postgres -p 5432
+          --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,24 +91,18 @@ jobs:
     environment: Dev
     if: ${{ inputs.postgres_unit_testing == true }}
     services:
-      # Label used to access the service container
       postgres:
-        # Bitnami image - same as the official one but more configurable. 
-        image: bitnami/postgresql:13
-        # Provide the password for postgres
+        image: postgres
         env:
-          POSTGRESQL_PASSWORD: postgres
-          POSTGRESQL_DATABASE: ${{inputs.db_name}}
-          POSTGRESQL_FSYNC: 'off'
-          POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
-        # Set health checks to wait until postgres has started
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_INITDB_ARGS: --no-sync
+          POSTGRES_DB: ${{inputs.db_name}}
         options: >-
-          --health-cmd pg_isready -d ${{inputs.db_name}} -U postgres -p 5432
+          --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
-          # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
       - name: checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,8 +97,8 @@ jobs:
         image: bitnami/postgresql:13
         # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DATABASE: ${{inputs.db_name}}
+          POSTGRESQL_PASSWORD: postgres
+          POSTGRESQL_DATABASE: ${{inputs.db_name}}
           POSTGRESQL_FSYNC: 'off'
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -d postgres -U postgres -p 5432"
           --health-interval 8s
           --health-timeout 2s
           --health-retries 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,18 +91,24 @@ jobs:
     environment: Dev
     if: ${{ inputs.postgres_unit_testing == true }}
     services:
+      # Label used to access the service container
       postgres:
-        image: postgres
+        # Bitnami image - same as the official one but more configurable. 
+        image: bitnami/postgresql:13
+        # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_INITDB_ARGS: --no-sync
-          POSTGRES_DB: ${{inputs.db_name}}
+          POSTGRESQL_PASSWORD: postgres
+          POSTGRESQL_DATABASE: ${{inputs.db_name}}
+          POSTGRESQL_FSYNC: 'off'
+          POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
+        # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
+          --health-cmd pg_isready -d ${{inputs.db_name}} -U postgres -p 5432
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
+          # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
       - name: checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,9 +104,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd "pg_isready -d postgres -U postgres -p 5432"
-          --health-interval 8s
-          --health-timeout 2s
-          --health-retries 10
+          --health-interval 12s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,12 +100,13 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: ${{inputs.db_name}}
           POSTGRESQL_FSYNC: 'off'
+          POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 12
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd 'pg_isready -d ${{inputs.db_name}} -U postgres -p 5432'
+          --health-cmd "pg_isready -d ${{inputs.db_name}} -U postgres -p 5432"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           POSTGRESQL_SYNCHRONOUS_COMMIT_MODE: 'off'
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd "pg_isready -d postgres -U postgres -p 5432"
+          --health-cmd "pg_isready --username=postgres"
           --health-interval 12s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,9 +104,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 12
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,12 +93,13 @@ jobs:
     services:
       # Label used to access the service container
       postgres:
-        # Docker Hub image
-        image: postgres
+        # Bitnami image - same as the official one but more configurable. 
+        image: bitnami/postgresql:13
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: ${{inputs.db_name}}
+          POSTGRESQL_FSYNC: 'off'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready


### PR DESCRIPTION
There are several settings we can change to speed up the set up/use of our postgres service in the workflow. We can do this because we don't care about data loss during CI testing.

Of course this means that performance testing isn't carried out - but it wasn't anyway....

_.Ideally, in the future this would be done before merging to main and repos would have a larger dataset which is used for this purpose...for now in the assessment_store you are warned if your sql queries are slow._

# Changes
- `fsync=off` don't sync files when writing changes to the db's documents.
- `asynchronous commits` don't bother syncing commits when writing to the file system. 
- Changed to using `postgres 13 `since that is the prod version.