### PR TITLE
FS-2172: remove ref from filename

### DIFF
--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -43,11 +43,11 @@ jobs:
         uses: thedoctor0/zip-release@main
         with:
           type: 'zip'
-          filename: '${{ github.event.repository.name }}-${{github.ref_name}}.zip'
+          filename: '${{ github.event.repository.name }}.zip'
           exclusions: '*.git* *.venv/* *tests/*'
 
       - name: Upload Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: '${{ github.event.repository.name }}-${{github.ref_name}}.zip'
+          artifacts: '${{ github.event.repository.name }}.zip'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is not required as Github already changes the URL path to include the tag. It will simplify the release process by not having to update number in two places.

Roll-out plan is to push new tags for all apps after this change and then update associated documentation in `terraform-prod` repo.
