### PR TITLE
FS-2172: add bump tag workflow

### DIFF
--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_call:
+  
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.61.0 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        PRERELEASE_SUFFIX: prerelease
+        DEFAULT_BUMP: patch
+


### PR DESCRIPTION
Adds workflow to automate incrementing and pushing tag, idea here is to automate previous manual steps of deploy process i.e. steps 1-4 in https://github.com/communitiesuk/funding-service-design-terraform-prod#updating-python-apps

Rollout plan is to add this to one app to test and then roll out more widely if successful.