### PR TITLE
Update github token permissions

### DIFF
--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -71,4 +71,3 @@ jobs:
 
       - name: Write Tag
         run: echo "### New Tag ${{ steps.bump-tag.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
- 

--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -71,3 +71,4 @@ jobs:
 
       - name: Write Tag
         run: echo "### New Tag ${{ steps.bump-tag.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
+ 

--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -1,4 +1,6 @@
 name: Tag to release
+permissions:
+  packages: write
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -1,6 +1,6 @@
 name: Tag to release
 permissions:
-  packages: write
+  contents: write
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Since moving to an Enterprise org it appears GITHUB_TOKEN has defaulted to restricted permissions as described in https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token so we need to specify the correct permissions for our workflows.