### PR TITLE
BAU: Add concurrency keys on e2e and performance test steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,8 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
-    concurrency: shared_tests_dev
+    # Waits for deploy_dev job to finish before running the tests
+    concurrency: deploy_dev_${{github.repository}}
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -280,7 +281,8 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
-    concurrency: shared_tests_test
+    # Waits for deploy_test job to finish before running the tests
+    concurrency: deploy_test_${{github.repository}}
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,6 +185,7 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
+    concurrency: shared_tests_dev
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -279,6 +280,7 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
+    concurrency: shared_tests_test
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:


### PR DESCRIPTION
Related to https://github.com/communitiesuk/funding-service-design-workflows/pull/43

Added concurrency keys for the e2e and performance test steps to ensure that e2e tests only run one at a time in one repo whilst there is a wait in another repo after a PR merge.

https://docs.github.com/en/actions/using-jobs/using-concurrency