### PR TITLE
FS 2385: Add concurrency keys on e2e and performance test steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,6 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
-    concurrency: run_shared_tests_dev
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -280,7 +279,6 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
-    concurrency: run_shared_tests_test
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,8 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
-    concurrency: shared_tests_dev
+    # Waits for deploy_dev job to finish before running the tests
+    concurrency: deploy_dev_${{github.repository}}
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -280,7 +281,8 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
-    concurrency: shared_tests_test
+    # Waits for deploy_test job to finish before running the tests
+    concurrency: deploy_test_${{github.repository}}
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,6 +185,7 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
+    concurrency: shared_tests_dev
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -279,6 +280,7 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
+    concurrency: shared_tests_test
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,8 +185,6 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
-    # Waits for deploy_dev job to finish before running the tests
-    concurrency: deploy_dev_${{github.repository}}
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -281,8 +279,6 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
-    # Waits for deploy_test job to finish before running the tests
-    concurrency: deploy_test_${{github.repository}}
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,6 +185,7 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
+    concurrency: run_shared_tests_dev
     if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -279,6 +280,7 @@ jobs:
 
   run_shared_tests_test:
     if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
+    concurrency: run_shared_tests_test
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -53,6 +53,7 @@ on:
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
+    concurrency: inputs.run_e2e_tests
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
       run:
@@ -87,6 +88,7 @@ jobs:
           
   run_performance_tests:
     runs-on: ubuntu-latest
+    concurrency: inputs.run_performance_tests
     if: ${{ inputs.run_performance_tests == true}}
     defaults:
       run:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -53,7 +53,6 @@ on:
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
-    concurrency: inputs.run_e2e_tests
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
       run:
@@ -88,7 +87,6 @@ jobs:
           
   run_performance_tests:
     runs-on: ubuntu-latest
-    concurrency: inputs.run_performance_tests
     if: ${{ inputs.run_performance_tests == true}}
     defaults:
       run:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -53,6 +53,8 @@ on:
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
+    # Waits for run_e2e_tests job to finish before running the tests
+    concurrency: run_e2e_tests
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
       run:
@@ -87,6 +89,8 @@ jobs:
           
   run_performance_tests:
     runs-on: ubuntu-latest
+    # Waits for run_performance_tests job to finish before running the tests
+    concurrency: run_performance_tests
     if: ${{ inputs.run_performance_tests == true}}
     defaults:
       run:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -53,8 +53,6 @@ on:
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
-    # Waits for run_e2e_tests job to finish before running the tests
-    concurrency: run_e2e_tests
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
       run:
@@ -89,8 +87,6 @@ jobs:
           
   run_performance_tests:
     runs-on: ubuntu-latest
-    # Waits for run_performance_tests job to finish before running the tests
-    concurrency: run_performance_tests
     if: ${{ inputs.run_performance_tests == true}}
     defaults:
       run:


### PR DESCRIPTION
Related to https://github.com/communitiesuk/funding-service-design-workflows/pull/43

Added concurrency keys for the e2e and performance tests steps to ensure that the tests don't run across repos at the same time. 

https://docs.github.com/en/actions/using-jobs/using-concurrency