### PR TITLE
FS-2407: Separate workflow step to separate out e2e tests for Application and Assessment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,7 +197,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: false
+      run_e2e_tests: true
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,7 +197,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: true
+      run_e2e_tests: false
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -74,6 +74,8 @@ jobs:
         run: npx wdio run ./wdio.conf_headless.js
         env:
           TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
+          EXCLUDE_ASSESSMENT: true
+          EXCLUDE_APPLICATION: false
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
           TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
           TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
@@ -81,7 +83,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: e2e-test-report
+          name: e2e-test-report-application
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
 
@@ -105,9 +107,11 @@ jobs:
       - name: Install
         run: npm install
       - name: Run WebDriver IO Tests
-        run: npx wdio run ./wdio.conf_headless_assessment.js
+        run:  npx wdio run wdio.conf_headless.js 
         env:
           TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
+          EXCLUDE_ASSESSMENT: false
+          EXCLUDE_APPLICATION: true
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
           TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
           TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
@@ -115,7 +119,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: e2e-test-report
+          name: e2e-test-report-assessment
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
           

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -51,7 +51,7 @@ on:
         required: false # TODO Make this true when all repos updated
 
 jobs:
-  run_e2e_tests:
+  run_application_e2e_test:
     runs-on: ubuntu-latest
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
@@ -77,7 +77,41 @@ jobs:
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
           TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
           TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
-      - name: Upload E2E Test Report
+      - name: Upload E2E Test Report Application
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-report
+          path: ./funding-service-design-e2e-checks/results
+          retention-days: 5
+
+  run_assessment_e2e_test:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.run_e2e_tests == true}}
+    defaults:
+      run:
+        working-directory: ./funding-service-design-e2e-checks
+    steps:
+      - name: Checkout E2E tests
+        uses: actions/checkout@v3
+        with:
+          repository: communitiesuk/funding-service-design-e2e-checks
+          path: ./funding-service-design-e2e-checks
+          token: ${{ secrets.E2E_PAT }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.3.0
+      - name: Install
+        run: npm install
+      - name: Run WebDriver IO Tests
+        run: npx wdio run ./wdio.conf_headless_assessment.js
+        env:
+          TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
+          TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
+          TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
+          TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
+      - name: Upload E2E Test Report Assessment
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Related to https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/163

I have created a separate workflow step so that e2e tests for application and assessment can now be easily identified in the pipeline run. 

The e2e tests for application and assessment each take env vars which enables these tests to run in isolation. 

This will make it much easier to debug issues between these frontends as each e2e test will now has it's own html report.

Example: https://github.com/communitiesuk/funding-service-design-fund-store/actions/runs/4325665931

![image](https://user-images.githubusercontent.com/36962596/222787549-a6be79cd-79c4-4e15-9042-7a570007fcb6.png)


