### PR TITLE
bau-explicit-version-for-bandit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,7 +238,7 @@ jobs:
         with:
           python-version: 3.10.x
       - name: install dependencies
-        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt bandit==1.7.4
       - name: Bandit
         run: bandit -r ./app
       - name: ZAP Scan


### PR DESCRIPTION
static security job also needs explicit (older) version of bandit for now as bandit has been updated in a few of the other repos using the shared workflow.