### PR TITLE
FS-2406: Updating tag-to-release workflow to include tag output

### DIFF
--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -7,7 +7,11 @@ on:
       build_static_assets:
         type: boolean
         required: false
-        default: true    
+        default: true
+    outputs:
+      new_tag:
+        description: "The version created from the new tagging process"
+        value: ${{ jobs.release_tag.outputs.exported_tag }}
 
 
 env:
@@ -19,6 +23,8 @@ jobs:
   release_tag:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      exported_tag: ${{ steps.bump-tag.outputs.new_tag }}
     steps:
 
       - name: Set env


### PR DESCRIPTION
* Add output to the entire workflow that uses an output on the release_tag job
* Add output to the release_tag job that uses an output from a step

Commits 0be754028238d49a8b3fb13a215d4e55f8a52ecb and 47df2d02eda545e9b853e4272e4f63c792185b55 to be removed once testing is complete