### PR TITLE
BAU: Add needs keyword to make assessment e2e tests for each fund run in a queue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: false
+      run_e2e_tests: true
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: true
+      run_e2e_tests: false
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -126,6 +126,7 @@ jobs:
           retention-days: 5
 
   run_nstf_assessment_e2e_test:
+    needs: [run_cof_assessment_e2e_test]
     runs-on: ubuntu-latest
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:


### PR DESCRIPTION
There seems to be some issues with the Test environment which causes the e2e assessment tests to run painfully slow and causes the tests to timeout.

I have now added the needs keyword so that the assessment e2e tests for each fund run in a queue.

This is what the workflow will look like going forward.

![image](https://github.com/communitiesuk/funding-service-design-workflows/assets/36962596/cbb02a01-f471-4ec4-8caa-03405fae92cf)
 

