### PR TITLE
BAU: Remove queue for e2e assessments tests per fund

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -126,7 +126,6 @@ jobs:
           retention-days: 5
 
   run_nstf_assessment_e2e_test:
-    needs: [run_cof_assessment_e2e_test]
     runs-on: ubuntu-latest
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:


### PR DESCRIPTION
Due to changes made in https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/373 to get the e2e assessments to rerun automatically if the test flakes, we don't need to have the e2e assessment test run in a queue on the pipeline as they can now run concurrently again.