### PR TITLE
BAU: Cache dependencies for e2e tests

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -68,8 +68,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.20.1
-      - name: Install
-        run: npm install
+      - name: Install dependencies 
+        run: npm ci
       - name: Run WebDriver IO Tests
         run: npx wdio run ./wdio.conf_headless.js
         env:
@@ -105,8 +105,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.20.1
-      - name: Install
-        run: npm install
+      - name: Install dependencies 
+        run: npm ci
       - name: Run WebDriver IO Tests
         run:  npx wdio run wdio.conf_headless.js 
         env:
@@ -126,6 +126,7 @@ jobs:
           retention-days: 5
 
   run_nstf_assessment_e2e_test:
+    needs: run_cof_assessment_e2e_test
     runs-on: ubuntu-latest
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
@@ -142,8 +143,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.20.1
-      - name: Install
-        run: npm install
+      - name: Install dependencies 
+        run: npm ci
       - name: Run WebDriver IO Tests
         run:  npx wdio run wdio.conf_headless.js 
         env:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -126,7 +126,6 @@ jobs:
           retention-days: 5
 
   run_nstf_assessment_e2e_test:
-    needs: run_cof_assessment_e2e_test
     runs-on: ubuntu-latest
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:


### PR DESCRIPTION
Related to:
https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/376

I have amended the yaml file so that it caches the dependencies every time there is a pipeline run through `npm ci.` 

