### PR TITLE
BAU: Turn NSTF Assessment E2E Tests Off

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: false
+      run_e2e_tests: true
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: true
+      run_e2e_tests: false
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -127,7 +127,7 @@ jobs:
 
   run_nstf_assessment_e2e_test:
     runs-on: ubuntu-latest
-    if: ${{ inputs.run_e2e_tests == true}}
+    if: false
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks
@@ -148,7 +148,7 @@ jobs:
         run:  npx wdio run wdio.conf_headless.js 
         env:
           TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
-          EXCLUDE_ASSESSMENT_NSTF: true
+          EXCLUDE_ASSESSMENT_NSTF: false
           EXCLUDE_ASSESSMENT_COF: true
           EXCLUDE_APPLICATION: true
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -148,7 +148,7 @@ jobs:
         run:  npx wdio run wdio.conf_headless.js 
         env:
           TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
-          EXCLUDE_ASSESSMENT_NSTF: false
+          EXCLUDE_ASSESSMENT_NSTF: true
           EXCLUDE_ASSESSMENT_COF: true
           EXCLUDE_APPLICATION: true
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}


### PR DESCRIPTION
This PR changes the condition for the NSTF Assessment E2E test so they skip when they're running against Test and UAT.

Reason for this is because Night Shelter is currently closed and there are no further rounds planned in the near future. 

Below is an example of what it will look like when the e2e tests are running. As you can see below, NSTF Assessment E2E test is skipped. 

The example below is from Dev.

<img width="182" alt="image" src="https://github.com/communitiesuk/funding-service-design-workflows/assets/36962596/a88b6574-c3c4-4c7d-a663-be63cce319de">
