### PR TITLE
BAU: Turn NSTF Assessment E2E Tests Off

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -127,7 +127,7 @@ jobs:
 
   run_nstf_assessment_e2e_test:
     runs-on: ubuntu-latest
-    if: ${{ inputs.run_e2e_tests == true}}
+    if: false
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -127,7 +127,7 @@ jobs:
 
   run_nstf_assessment_e2e_test:
     runs-on: ubuntu-latest
-    if: false
+    if: false # This will skip this e2e test as no new active rounds are in flight currently for this fund
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks


### PR DESCRIPTION
This PR changes the condition for the NSTF Assessment E2E test so they skip when they're running against Test and UAT.

Reason for this is because Night Shelter is currently closed and there are no further rounds planned in the near future. 

Below is an example of what it will look like when the e2e tests are running. As you can see below, NSTF Assessment E2E test is skipped. 

The example below is from the e2e tests running against Dev.

<img width="182" alt="image" src="https://github.com/communitiesuk/funding-service-design-workflows/assets/36962596/a88b6574-c3c4-4c7d-a663-be63cce319de">