### PR TITLE
BAU: Refactor Run Shared Tests YAML File

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: false
+      run_e2e_tests: true
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests: true
+      run_e2e_tests: false
     secrets:
        E2E_PAT: ${{secrets.E2E_PAT}}
 

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -70,12 +70,11 @@ jobs:
           node-version: 14.20.1
       - name: Install dependencies 
         run: npm ci
-      - name: Run WebDriver IO Tests
+      - name: Run E2E Tests Application For All Funds
         run: npx wdio run ./wdio.conf_headless.js
         env:
           TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
-          EXCLUDE_ASSESSMENT_COF: true
-          EXCLUDE_ASSESSMENT_NSTF: true
+          EXCLUDE_ASSESSMENT: true
           EXCLUDE_APPLICATION: false
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
           TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
@@ -88,7 +87,7 @@ jobs:
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
 
-  run_cof_assessment_e2e_test:
+  run_assessment_e2e_test:
     runs-on: ubuntu-latest
     if: ${{ inputs.run_e2e_tests == true}}
     defaults:
@@ -107,58 +106,20 @@ jobs:
           node-version: 14.20.1
       - name: Install dependencies 
         run: npm ci
-      - name: Run WebDriver IO Tests
+      - name: Run E2E Tests Assessment For All Funds
         run:  npx wdio run wdio.conf_headless.js 
         env:
           TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
-          EXCLUDE_ASSESSMENT_COF: false
-          EXCLUDE_ASSESSMENT_NSTF: true
+          EXCLUDE_ASSESSMENT: false
           EXCLUDE_APPLICATION: true
           TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
           TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
           TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
-      - name: Upload E2E Test Report COF Assessment
+      - name: Upload Assessment E2E Test Report
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: e2e-test-report-cof-assessment
-          path: ./funding-service-design-e2e-checks/results
-          retention-days: 5
-
-  run_nstf_assessment_e2e_test:
-    runs-on: ubuntu-latest
-    if: false # This will skip this e2e test as no new active rounds are in flight currently for this fund
-    defaults:
-      run:
-        working-directory: ./funding-service-design-e2e-checks
-    steps:
-      - name: Checkout E2E tests
-        uses: actions/checkout@v3
-        with:
-          repository: communitiesuk/funding-service-design-e2e-checks
-          path: ./funding-service-design-e2e-checks
-          token: ${{ secrets.E2E_PAT }}
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.20.1
-      - name: Install dependencies 
-        run: npm ci
-      - name: Run WebDriver IO Tests
-        run:  npx wdio run wdio.conf_headless.js 
-        env:
-          TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
-          EXCLUDE_ASSESSMENT_NSTF: false
-          EXCLUDE_ASSESSMENT_COF: true
-          EXCLUDE_APPLICATION: true
-          TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
-          TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
-          TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
-      - name: Upload E2E Test Report NSTF Assessment
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: e2e-test-report-nstf-assessment
+          name: e2e-test-report-assessment
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
           


### PR DESCRIPTION
Related to https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/427

The following changes were done:

- Renamed job names for running application and assessment e2e tests
- Removed references to NSTF in the YAML file as the application and assessment window is closed and we no longer need a separate job to run a separate set of assessment e2e tests. All can just run from " e2e-test-assessment"
- Removed references to COF in the YAML file
- Renamed "Rename WebDriver IO Test" to a more meaningful name
- Renamed environment variables


Please note that the e2e test failures are on Dev only due to Fund Store not being configured for certain funds on Dev.

![image](https://github.com/communitiesuk/funding-service-design-workflows/assets/36962596/b3147955-5969-433a-bdc1-b67f71a27390)

