### PR TITLE
remove venv from static assets build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,18 +45,14 @@ jobs:
           python-version: 3.10.x
           cache: 'pip'
           cache-dependency-path: 'requirements.txt'
-
-      - name: create python env
-        if: ${{inputs.assets_required == true}}
-        run: python -m venv .venv
-
+          
       - name: install dependencies
         if: ${{inputs.assets_required == true}}
-        run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
+        run: python -m pip install --upgrade pip && pip install -r requirements.txt
 
       - name: build static assets (if frontend)
         if: ${{inputs.assets_required == true}}
-        run: source .venv/bin/activate && python build.py
+        run: python build.py
 
       - name: Build and publish app image
         run: "pack build ${{ env.DOCKER_IMAGE }} --builder paketobuildpacks/builder-jammy-full"


### PR DESCRIPTION
Pulling the requirements into the checkout directory means they're being included unnecessarily in the built image e.g.
```
$ docker run -it --entrypoint /bin/sh ghcr.io/communitiesuk/funding-service-design-post-award-submit:smd-334-packeto-buildpack      
$ ls .venv
bin  include  lib  lib64  pyvenv.cfg
```

This changes to use system python for the local requirements build. This also fixes the requirements cache, as it will now find them in the `pip` cache