### PR TITLE
build and publish cache image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,23 +55,14 @@ jobs:
         run: python build.py
 
       - name: Build and publish app image
-        run: "pack build ${{ env.DOCKER_IMAGE }} --builder paketobuildpacks/builder-jammy-full"
-
-      - name: Push image
         run: |
           IMAGE_ID=${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}
-
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
           VERSION=${{ inputs.version_to_build }}
-
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
-
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag ${{ env.DOCKER_IMAGE }} $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          pack build $IMAGE_ID:$VERSION --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/buildpack-packeto-cache-image --publish 


### PR DESCRIPTION
Uses the `--cache-image` functionality of packeto (https://buildpacks.io/docs/app-developer-guide/using-cache-image/) to store cached layers to speed up subsequent builds. As `--publish` flag is set packeto also publishes the image so there's no need for a separate docker push step. 

Have found in testing this reduces the build and push time by ~50%
e.g. compare: https://github.com/communitiesuk/funding-service-design-post-award-submit/actions/runs/6861712149/job/18665789561 to https://github.com/communitiesuk/funding-service-design-post-award-submit/actions/runs/6879617185/job/18712033034