### PR TITLE
BAU: Upgrade Node Version to 19 for E2E Tests Workflow

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.20.1
+          node-version: 19
       - name: Install dependencies 
         run: npm ci
       - name: Run E2E Tests Application For All Funds
@@ -103,7 +103,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.20.1
+          node-version: 19
       - name: Install dependencies 
         run: npm ci
       - name: Run E2E Tests Assessment For All Funds


### PR DESCRIPTION
Related to:
https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/462

This PR upgrades the node version to v19 to be compatible with the latest version of chromedriver.