### PR TITLE
BAU: Upgrade Node Version and packages associated with E2E test workflow

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -59,15 +59,15 @@ jobs:
         working-directory: ./funding-service-design-e2e-checks
     steps:
       - name: Checkout E2E tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: communitiesuk/funding-service-design-e2e-checks
           path: ./funding-service-design-e2e-checks
           token: ${{ secrets.E2E_PAT }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14.20.1
+          node-version: 19
       - name: Install dependencies 
         run: npm ci
       - name: Run E2E Tests Application For All Funds
@@ -95,15 +95,15 @@ jobs:
         working-directory: ./funding-service-design-e2e-checks
     steps:
       - name: Checkout E2E tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: communitiesuk/funding-service-design-e2e-checks
           path: ./funding-service-design-e2e-checks
           token: ${{ secrets.E2E_PAT }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14.20.1
+          node-version: 19
       - name: Install dependencies 
         run: npm ci
       - name: Run E2E Tests Assessment For All Funds


### PR DESCRIPTION
Related to:
https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/462

This PR upgrades the node version to v19 to be compatible with the latest version of chromedriver.

Also update actions/checkout@v4.1.1 and actions/setup-node@v4 to these respective versions so that it can work with node v19. 