### PR TITLE
BAU - Allow delete message for the assessment queue

### DIFF
--- a/apps/pre-award/copilot/environments/addons/assessment-import-queue.yml
+++ b/apps/pre-award/copilot/environments/addons/assessment-import-queue.yml
@@ -36,6 +36,7 @@ Resources:
             Action:
               - "SQS:SendMessage"
               - "SQS:ReceiveMessage"
+              - "SQS:DeleteMessage"
             Effect: "Allow"
             Resource: !GetAtt AssessmentImportQueue.Arn
             Principal:


### PR DESCRIPTION
It is necessary to have DeleteMessage to remove a message once it is handled.