### PR TITLE
updated workflow to take arguments about which e2e tests to execute

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -18,6 +18,15 @@ on:
         required: false
         default: false
         type: boolean
+      run_e2e_tests_application:
+        required: false
+        default: true
+        type: boolean
+      run_e2e_tests_assessment:
+        required: false
+        default: true
+        type: boolean
+      # Leave this in for backwards compatibility, but remove once all repos updated to use above inputs
       run_e2e_tests:
         required: false
         default: false
@@ -62,7 +71,8 @@ jobs:
       e2e_tests_target_url_assessment: https://fsd:fsd@assessment.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk
       # run_performance_tests: ${{inputs.run_performance_tests}}
       run_performance_tests: false
-      run_e2e_tests: ${{inputs.run_e2e_tests}}
+      run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
+      run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -38,7 +38,11 @@ on:
         required: false
         default: false
         type: boolean
-      run_e2e_tests:
+      run_e2e_tests_application:
+        required: false
+        default: true
+        type: boolean
+      run_e2e_tests_assessment:
         required: false
         default: true
         type: boolean
@@ -56,7 +60,7 @@ on:
 jobs:
   run_application_e2e_test:
     runs-on: ubuntu-latest
-    if: ${{ inputs.run_e2e_tests == true}}
+    if: ${{ inputs.run_e2e_tests_application == true}}
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks
@@ -101,7 +105,7 @@ jobs:
 
   run_assessment_e2e_test:
     runs-on: ubuntu-latest
-    if: ${{ inputs.run_e2e_tests == true}}
+    if: ${{ inputs.run_e2e_tests_assessment == true}}
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks


### PR DESCRIPTION
Added arguments to workflow to specify whether to run the assessment or application e2e tests separately.