### PR TITLE
FS-3974 - Use later version of token generator to fail gracefully

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1.6.4
         with:
           app-id: ${{ secrets.FSD_GH_APP_ID }}
           private-key: ${{ secrets.FSD_GH_APP_KEY }}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1.6.4
         with:
           app-id: ${{ secrets.FSD_GH_APP_ID }}
           private-key: ${{ secrets.FSD_GH_APP_KEY }}
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1.6.4
         with:
           app-id: ${{ secrets.FSD_GH_APP_ID }}
           private-key: ${{ secrets.FSD_GH_APP_KEY }}
@@ -157,7 +157,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1.6.4
         with:
           app-id: ${{ secrets.FSD_GH_APP_ID }}
           private-key: ${{ secrets.FSD_GH_APP_KEY }}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3974

Use a later version of the app-token retrieval so expired tokens are revoked gracefully without failing the jobs.