### PR TITLE
Bau fix assessment reports

### DIFF
--- a/.github/workflows/just-run-tests.yml
+++ b/.github/workflows/just-run-tests.yml
@@ -44,6 +44,7 @@ jobs:
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
+      env_name: dev
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
@@ -62,9 +63,11 @@ jobs:
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
+      env_name: test
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+
   run_shared_tests_uat:
     if: ${{ always() && inputs.uat == true }}
     uses: ./.github/workflows/run-shared-tests.yml
@@ -79,6 +82,7 @@ jobs:
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
+      env_name: uat
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -107,6 +107,7 @@ jobs:
       run_performance_tests: false
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
+      env_name: ${{inputs.environment}}
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -126,17 +126,16 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: "funding-service-design-e2e-checks"
 
-      - name: 'Set unique id'
-        id: unique_id
-        run: |
-          echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
-
       - name: Checkout E2E tests
         uses: actions/checkout@v4.1.1
         with:
           repository: communitiesuk/funding-service-design-e2e-checks
           path: ./funding-service-design-e2e-checks
           token: ${{ steps.generate_token.outputs.token }}
+      - name: 'Set unique id'
+        id: unique_id
+        run: |
+          echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -126,6 +126,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: "funding-service-design-e2e-checks"
 
+      - name: 'Set unique id'
+        id: unique_id
+        run: |
+          echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
+
       - name: Checkout E2E tests
         uses: actions/checkout@v4.1.1
         with:
@@ -151,7 +156,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-report-assessment
+          name: e2e-test-report-assessment-${{ steps.unique_id.outputs.unique_id }}
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
 

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -50,6 +50,9 @@ on:
         required: false
         default: false
         type: boolean
+      env_name:
+        required: true
+        type: string
     secrets:
       FSD_GH_APP_ID:
         required: true
@@ -64,8 +67,6 @@ jobs:
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks
-    outputs:
-      unique_id: ${{ steps.unique_id.outputs.unique_id }}
     steps:
       - name: Generate a token
         id: generate_token
@@ -106,7 +107,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-report-application-${{ steps.unique_id.outputs.unique_id }}
+          name: e2e-test-report-application-${{inputs.env_name}}-${{ steps.unique_id.outputs.unique_id }}
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
 
@@ -155,7 +156,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-report-assessment-${{ steps.unique_id.outputs.unique_id }}
+          name: e2e-test-report-assessment-${{inputs.env_name}}-${{ steps.unique_id.outputs.unique_id }}
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
 
@@ -181,6 +182,10 @@ jobs:
           repository: communitiesuk/funding-service-design-performance-tests
           path: ./funding-service-design-performance-tests
           token: ${{ steps.generate_token.outputs.token }}
+      - name: 'Set unique id'
+        id: unique_id
+        run: |
+          echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -202,7 +207,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: performance-test-report
+          name: performance-test-report-${{inputs.env_name}}-${{ steps.unique_id.outputs.unique_id }}
           path: ./funding-service-design-performance-tests/locust_html_report.html
           retention-days: 5
 


### PR DESCRIPTION
Continuing Rob's fix from FS-4224 and applying it to assessment as well
- Updating the name of the report file that gets uploaded to include the environment name and a timestamp to prevent name conflicts when a job is rerun or across multiple environments