### PR TITLE
bumped zap scan version to 0.10.0

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -141,7 +141,7 @@ jobs:
     environment: test
     steps:
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.4.0
+        uses: zaproxy/action-full-scan@v0.10.0
         with:
           target: "https://${{inputs.app_name}}.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk/"
           allow_issue_writing: False


### PR DESCRIPTION
Bumped the ZAP version to 0.10.0 as the previous version no longer existed and was breaking builds