### PR TITLE
BAU: Don't run deploy if user is dependabot

### DIFF
--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     concurrency:
       group: 'fsd-preaward-${{ inputs.environment }}'
       cancel-in-progress: false


### PR DESCRIPTION
As dependabot doesn't have access to secrets it cannot deploy successfully.
You can see this has caused many failures on dependabot PRs e.g. https://github.com/communitiesuk/funding-service-design-account-store/pull/215