### PR TITLE
Removing dev from list of jobs generated

### DIFF
--- a/.github/workflows/determine-jobs.yml
+++ b/.github/workflows/determine-jobs.yml
@@ -20,9 +20,7 @@ jobs:
                 if [ "${{ inputs.environment }}" != '' ]; then
                     export jobs='["${{ inputs.environment }}"]'
                 elif [ "${{ github.ref }}" == 'refs/heads/main' ]; then
-                    export jobs='["dev", "test", "uat", "prod"]'
-                else
-                    export jobs='["dev"]'
+                    export jobs='["test", "uat", "prod"]'
                 fi
                 echo "job_list=$(jq -cn --argjson keys "$jobs" '$keys')" >> $GITHUB_OUTPUT
                 cat $GITHUB_OUTPUT


### PR DESCRIPTION
Removing `dev` from the automatic list of jobs generated when a workflow runs. It will now:

- Deploy to the selected environment if run manually
- Deploy to nothing if from a branch
- Deploy to `test`, `uat` and `prod` from main.