### PR TITLE
removing db requirements from frontend tests

### DIFF
--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements-dev.txt'
       - name: install dependencies
-        run: python -m pip install --upgrade pip && python -m pip install -r ./funding-service-design-base/python-flask/requirements.txt -r ./funding-service-design-base/python-flask/requirements-dev.txt -r ./funding-service-design-base/python-flask/requirements-db.txt -r ./funding-service-design-base/python-flask/requirements-frontend.txt -r requirements-dev.txt
+        run: python -m pip install --upgrade pip && python -m pip install -r ./funding-service-design-base/python-flask/requirements.txt -r ./funding-service-design-base/python-flask/requirements-dev.txt -r ./funding-service-design-base/python-flask/requirements-frontend.txt -r requirements-dev.txt
       - name: build static assets (if frontend)
         if: ${{inputs.assets_required == true}}
         env:
@@ -94,7 +94,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements-dev.txt'
       - name: install dependencies
-        run: python -m pip install --upgrade pip && python -m pip install -r ./funding-service-design-base/python-flask/requirements.txt -r ./funding-service-design-base/python-flask/requirements-dev.txt -r ./funding-service-design-base/python-flask/requirements-db.txt -r ./funding-service-design-base/python-flask/requirements-frontend.txt -r requirements-dev.txt
+        run: python -m pip install --upgrade pip && python -m pip install -r ./funding-service-design-base/python-flask/requirements.txt -r ./funding-service-design-base/python-flask/requirements-dev.txt -r ./funding-service-design-base/python-flask/requirements-db.txt -r requirements-dev.txt
       - name: run unit tests
         run: python -m pip install pytest && python -m pytest -m "not accessibility"
         env:


### PR DESCRIPTION
Updated the test tasks in the actions so that:
- DB requirements are not installed for frontend tests
- Frontend requirements are not installed for db tests