### PR TITLE
Don't use `--create`

### DIFF
--- a/scripts/aws_db_dump_restore.sh
+++ b/scripts/aws_db_dump_restore.sh
@@ -44,19 +44,18 @@ aws ssm start-session --target $TARGET_BASTION --document-name AWS-StartPortForw
 sleep 5
 
 SOURCE_URL=postgres://$SOURCE_USERNAME:$SOURCE_PASSWORD@localhost:$SOURCE_LPORT/$SOURCE_DBNAME
-TARGET_URL=postgres://$TARGET_USERNAME:$TARGET_PASSWORD@localhost:$TARGET_LPORT/postgres
-TARGET_URL_DATA_API_DB=postgres://$TARGET_USERNAME:$TARGET_PASSWORD@localhost:$TARGET_LPORT/$TARGET_DBNAME
+TARGET_URL=postgres://$TARGET_USERNAME:$TARGET_PASSWORD@localhost:$TARGET_LPORT/$TARGET_DBNAME
 
 psql ${SOURCE_URL} <<EOF > source_count.txt
 select 'source', 0 union all select 'alembic_version', count(*) from alembic_version union all select 'fund_dim', count(*) from fund_dim union all select 'funding', count(*) from funding union all select 'funding_comment', count(*) from funding_comment union all select 'funding_question', count(*) from funding_question union all select 'geospatial_dim', count(*) from geospatial_dim union all select 'organisation_dim', count(*) from organisation_dim union all select 'outcome_data', count(*) from outcome_data union all select 'outcome_dim', count(*) from outcome_dim union all select 'output_data', count(*) from output_data union all select 'output_dim', count(*) from output_dim union all select 'place_detail', count(*) from place_detail union all select 'private_investment', count(*) from private_investment union all select 'programme_dim', count(*) from programme_dim union all select 'programme_funding_management', count(*) from programme_funding_management union all select 'programme_junction', count(*) from programme_junction union all select 'programme_progress', count(*) from programme_progress union all select 'project_dim', count(*) from project_dim union all select 'project_finance_change', count(*) from project_finance_change union all select 'project_geospatial_association', count(*) from project_geospatial_association union all select 'project_progress', count(*) from project_progress union all select 'risk_register', count(*) from risk_register union all select 'submission_dim', count(*) from submission_dim ORDER BY 1
 EOF
 
 echo "Doing dump and restore..."
-pg_dump $SOURCE_URL -v -F c --clean --create | pg_restore -d $TARGET_URL -v --clean --create
+pg_dump $SOURCE_URL -v -F c --clean | pg_restore -d $TARGET_URL -v --clean
 psql ${TARGET_URL} -c "ANALYZE;"
 echo "Completed dump and restore."
 
-psql ${TARGET_URL_DATA_API_DB} <<EOF > target_count.txt
+psql ${TARGET_URL} <<EOF > target_count.txt
 select 'target', 0 union all select 'alembic_version', count(*) from alembic_version union all select 'fund_dim', count(*) from fund_dim union all select 'funding', count(*) from funding union all select 'funding_comment', count(*) from funding_comment union all select 'funding_question', count(*) from funding_question union all select 'geospatial_dim', count(*) from geospatial_dim union all select 'organisation_dim', count(*) from organisation_dim union all select 'outcome_data', count(*) from outcome_data union all select 'outcome_dim', count(*) from outcome_dim union all select 'output_data', count(*) from output_data union all select 'output_dim', count(*) from output_dim union all select 'place_detail', count(*) from place_detail union all select 'private_investment', count(*) from private_investment union all select 'programme_dim', count(*) from programme_dim union all select 'programme_funding_management', count(*) from programme_funding_management union all select 'programme_junction', count(*) from programme_junction union all select 'programme_progress', count(*) from programme_progress union all select 'project_dim', count(*) from project_dim union all select 'project_finance_change', count(*) from project_finance_change union all select 'project_geospatial_association', count(*) from project_geospatial_association union all select 'project_progress', count(*) from project_progress union all select 'risk_register', count(*) from risk_register union all select 'submission_dim', count(*) from submission_dim ORDER BY 1
 EOF
 


### PR DESCRIPTION
In the current post-award(data-store) world, our dbname is `data_api_db`. In pre-award(post-award) world, our dbname is `post_award`.

Using the `--create` flag means that we are restoring into target db under the `data_api_db` name, which is wrong.

If we drop `--create` and just use `--clean`, then everything gets restored into the database we're connected to - which will be from the URI, and be the correct (`post_award`) location.