### PR TITLE
FS-3840: Post deploy E2E tests workflow to use Node 21

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 21
       - name: Install dependencies
         run: npm ci
       - name: Run E2E Tests Application For All Funds
@@ -140,7 +140,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 21
       - name: Install dependencies
         run: npm ci
       - name: Run E2E Tests Assessment For All Funds


### PR DESCRIPTION
E2E tests are failing to run because the version needs to be updated as the e2e tests repo upgraded to Node 21