### PR TITLE
Find download reports should expire after 7 days

### DIFF
--- a/apps/pre-award/copilot/environments/addons/post-award-find-download-files.yml
+++ b/apps/pre-award/copilot/environments/addons/post-award-find-download-files.yml
@@ -29,9 +29,10 @@ Resources:
           - ObjectOwnership: BucketOwnerEnforced
       LifecycleConfiguration:
         Rules:
-          - Id: ExpireNonCurrentObjects
+          - Id: ExpireFilesAfter7Days
             Status: Enabled
-            NoncurrentVersionExpirationInDays: 30
+            ExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 1
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 1
 


### PR DESCRIPTION
We missed this lifecycle configuration when migrating to the monolith, seemingly.