### PR TITLE
BAU: Remove duplicate trigger

### DIFF
--- a/.github/workflows/update-preaward-env.yml
+++ b/.github/workflows/update-preaward-env.yml
@@ -17,10 +17,7 @@ on:
       - '!**/README.md'
     branches: # Only run this workflow on pushes to the main branch
       - main
-  pull_request:
-    types:
-      - closed # Further protection - only allow this workflow to run automatically on closed pull requests
-
+      
 jobs:
   copilot_environments_workflow_setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This was causing a duplicate deployment on merge e.g.
![Screenshot 2024-09-02 at 11 09 24](https://github.com/user-attachments/assets/993b6646-5f67-4248-bc5d-cd7bf175fea5)
And one of these would fail.

There is no need for the additional check as we have branch protection on pushes to `main`.