### PR TITLE
FPASF-223: set deterministic name for sanitised dumps bucket

### DIFF
--- a/apps/pre-award/copilot/environments/addons/sanitised-database-dumps.yml
+++ b/apps/pre-award/copilot/environments/addons/sanitised-database-dumps.yml
@@ -15,6 +15,7 @@ Resources:
       'aws:copilot:description': 'An Amazon S3 bucket, sanitised-database-dumps, for storing and retrieving objects'
     Type: AWS::S3::Bucket
     Properties:
+      BucketName: !Sub fs-sanitised-database-dumps-${Env}
       VersioningConfiguration:
         Status: Enabled
       AccessControl: Private


### PR DESCRIPTION
Explicitly set a deterministic name, In order to make it easier to look up the x-account bucket