### PR TITLE
When e2e triggered this will avoid getting main to run the tests instead, it will get the latest tagged version to run the tests

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -84,6 +84,20 @@ jobs:
           path: ./funding-service-design-e2e-checks
           token: ${{ steps.generate_token.outputs.token }}
 
+      # Step 2: Fetch tags and find the latest tag
+      - name: Fetch all tags
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Latest tag: $LATEST_TAG"
+
+      # Step 3: Check out the latest tag
+      - name: Checkout latest tag
+        run: |
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_TAG
+          echo "Checked out tag: $LATEST_TAG"
+
       - name: 'Set unique id'
         id: unique_id
         run: |


### PR DESCRIPTION
With this PR it will not take the main branch to run the tests instead it will get the latest tagged version & run the tests this will reduce the amount of blocks currently having due to the e2e changes.