### PR TITLE
Switch from yq to jq

### DIFF
--- a/scripts/aws_connect_db.sh
+++ b/scripts/aws_connect_db.sh
@@ -57,6 +57,13 @@ then
     exit 1
 fi
 
+which jq >/dev/null
+if [ $? -ne 0 ]
+then
+    echo "Please install jq - this is needed to interpret the required secret values."
+    exit 1
+fi
+
 if [ $GUI -eq 0 ]
 then
     which psql >/dev/null 2>&1


### PR DESCRIPTION
Could not get `yq` to work on linux. We had this problem a while ago when we were doing the monolith migration.

`jq` should work without any troubles.

# How to test?
If you have a Mac, please try see if you can connect to `test` db. 