### PR TITLE
Bandit fix

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -133,7 +133,7 @@ jobs:
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt bandit==1.7.4
       - name: Bandit
         working-directory: ${{ inputs.app_name}}
-        run: bandit -r ./app
+        run: bandit -r . -lll
 
   zap-scan-aws:
     if: inputs.app_name != '' && inputs.run_zap_scan == true


### PR DESCRIPTION
I tried a few different things example verbose run: 
https://github.com/communitiesuk/funding-service-design-authenticator/actions/runs/11631722517/job/32393348190?pr=349

It's running on everything inside the project...
`-lll` makes it to throw an error only for `High`  level severity issues.

## How to test?
It's a bit annoying. But perhaps easiest is to clone [this branch](https://github.com/communitiesuk/funding-service-design-authenticator/pull/349/files).

If you want to test on local.
1. cd to authenticator dir
2. source venv
3. `pip install -r requirements-dev.txt bandit==1.7.4`
4. `bandit -v -r . -x /.venv -lll` (you have to ignore `.venv` on local)