### PR TITLE
Remove pip cache - failing some runs with uv

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           if [ -f uv.lock ]; then
             uv sync
-            uv export --format requirements-txt --no-hashes > requirements.txt
           else
             python -m pip install --upgrade pip && pip install -r requirements.txt
           fi
@@ -76,5 +75,9 @@ jobs:
           [ "$VERSION" == "main" ] && VERSION=latest
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
+
+          if [ -f uv.lock ]; then
+            uv export --format requirements-txt --no-hashes > requirements.txt
+          fi
 
           pack build $IMAGE_ID:$VERSION --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}/buildpack-packeto-cache-image --publish

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.10.x
-          cache: 'pip'
-          cache-dependency-path: 'requirements.txt'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.10.x
-          cache: 'pip'
-          cache-dependency-path: 'requirements-dev.txt'
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: install dependencies
@@ -100,8 +98,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.10.x
-          cache: 'pip'
-          cache-dependency-path: 'requirements-dev.txt'
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: install dependencies
@@ -118,4 +114,3 @@ jobs:
           else
             python -m pip install pytest && python -m pytest -m "not accessibility"
           fi
-


### PR DESCRIPTION
Caching will be re-enabled once we're switched over to `uv` fully.

Some `uv`-converted apps are now failing CICD because dependencies aren't getting installed by `pip`, so there's no cache for `pip` to save on teardown, and it throws an error for that situation.

Also fixes a bug where `uv` would only export `requirements.txt` if `assets_required` was set as true.

[Example of bad](https://github.com/communitiesuk/funding-service-design-assessment-store/actions/runs/11798848385/job/32865984294)
[Example of fix]()