### PR TITLE
Remove old pip-style path from workflows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,21 +49,11 @@ jobs:
 
       - name: install dependencies
         if: ${{inputs.assets_required == true}}
-        run: |
-          if [ -f uv.lock ]; then
-            uv sync
-          else
-            python -m pip install --upgrade pip && pip install -r requirements.txt
-          fi
+        run: uv sync
 
       - name: build static assets (if frontend)
         if: ${{inputs.assets_required == true}}
-        run: |
-          if [ -f uv.lock ]; then
-            uv run python build.py
-          else
-            python build.py
-          fi
+        run: uv run python build.py
 
       - name: Build and publish app image
         run: |
@@ -75,9 +65,7 @@ jobs:
           [ "$VERSION" == "main" ] && VERSION=latest
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-
-          if [ -f uv.lock ]; then
-            uv export --format requirements-txt --no-hashes > requirements.txt
-          fi
+          
+          uv export --format requirements-txt --no-hashes > requirements.txt
 
           pack build $IMAGE_ID:$VERSION --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}/buildpack-packeto-cache-image --publish

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -132,20 +132,10 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: install dependencies
         working-directory: ${{ inputs.app_name}}
-        run: |
-          if [ -f uv.lock ]; then
-            uv add --dev bandit==1.7.4
-          else
-            python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt bandit==1.7.4
-          fi
+        run: uv add --dev bandit==1.7.4
       - name: Bandit
         working-directory: ${{ inputs.app_name}}
-        run: |
-          if [ -f uv.lock ]; then
-            uv run bandit --exclude */.venv/* -r . -lll
-          else
-            bandit -r . -lll
-          fi
+        run: uv run bandit --exclude */.venv/* -r . -lll
 
   zap-scan-aws:
     if: inputs.app_name != '' && inputs.run_zap_scan == true

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -40,34 +40,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: install dependencies
-        run: |
-          if [ -f uv.lock ]; then
-            uv sync
-          else
-            python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
-          fi
+        run: uv sync
       - name: build static assets (if frontend)
         if: ${{inputs.assets_required == true}}
         env:
           FLASK_ENV: "development"
-        run: |
-          if [ -f uv.lock ]; then
-            uv run python build.py
-          else
-            python build.py
-          fi
+        run: uv run python build.py
       - name: run unit tests
         env:
           GOV_NOTIFY_API_KEY: ${{ secrets.GOV_NOTIFY_API_KEY }}
         # pytest -m "not accessibility" runs every test which is not marked
         # accessibility.
-        run: |
-          if [ -f uv.lock ]; then
-            uv run python -m pytest -m "not accessibility" .
-          else
-            python -m pip install pytest && python -m pytest -m "not accessibility" .
-          fi
-
+        run: uv run python -m pytest -m "not accessibility" .
 
   testing-unit-postgres-aws:
     runs-on: ubuntu-latest
@@ -101,16 +85,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: install dependencies
-        run: |
-          if [ -f uv.lock ]; then
-            uv sync
-          else
-            python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
-          fi
+        run: uv sync
       - name: run unit tests
-        run: |
-          if [ -f uv.lock ]; then
-            uv run python -m pytest -m "not accessibility"
-          else
-            python -m pip install pytest && python -m pytest -m "not accessibility"
-          fi
+        run: uv run python -m pytest -m "not accessibility"

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -194,27 +194,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: install dependencies
-        run: |
-          if [ -f uv.lock ]; then
-            uv sync
-          else
-            python -m venv .venv
-            source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
-          fi
+        run: uv sync
       - name: Run performance tests
         env:
           TARGET_URL_FUND_STORE: ${{inputs.perf_test_target_url_fund_store}}
           TARGET_URL_APPLICATION_STORE: ${{inputs.perf_test_target_url_application_store}}
           TARGET_URL_ASSESSMENT_STORE: ${{inputs.perf_test_target_url_assessment_store}}
-        run: |
-          if [ -f uv.lock ]; then
-            uv run python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}}
-          else
-            ls
-            source .venv/bin/activate
-            python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}}
-          fi
-
+        run: uv run python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}}
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-87

All of our apps are now using [`uv`](https://docs.astral.sh/uv/) for their dependency management and deployment, so we don't need the old pip-style codepath anymore.