### PR TITLE
FSPT-63: Update workflows for new combined pre-award-stores repo

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -122,7 +122,7 @@ jobs:
       - name: checkout app code for ${{inputs.app_name}}
         uses: actions/checkout@v4
         with:
-          repository: communitiesuk/funding-service-design-${{inputs.app_name}}
+          repository: ${{ github.repository_owner }}/${{ github.event.repository.name }}
           path: ${{inputs.app_name}}
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -65,7 +65,7 @@ jobs:
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: ${{inputs.db_name}}
+          POSTGRES_DB: ${{ inputs.db_name }}
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -88,3 +88,5 @@ jobs:
         run: uv sync
       - name: run unit tests
         run: uv run python -m pytest -m "not accessibility"
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/${{ inputs.db_name }}

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -80,4 +80,5 @@ jobs:
     - name: Copilot ${{ inputs.environment }} deploy
       id: deploy_build
       run: |
+        copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
         copilot svc deploy --env ${{ inputs.environment }} --app pre-award

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -9,13 +9,18 @@ on:
         required: true
         type: string
       version:
+        description: "DEPRECATED: Used to build `image_location`. Please prefer to provide `image_location` explicitly."
         required: true
         type: string
       db_name:
         required: false
         type: string
         default: ''
-    secrets: 
+      image_location:
+        description: "Location of the image to deploy."
+        type: string
+        required: false
+    secrets:
       AWS_ACCOUNT:
         required: true
 
@@ -65,7 +70,8 @@ jobs:
 
     - name: Inject replacement image into manifest
       run: |
-        yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-${{ inputs.app_name }}:${{ inputs.version }}"'  copilot/fsd-${{ inputs.app_name }}/manifest.yml
+        export IMAGE_LOCATION="${{ inputs.image_location || format('ghcr.io/communitiesuk/funding-service-design-{0}:{1}', inputs.app_name, inputs.version) }}"
+        yq -i ".image.location = \"${IMAGE_LOCATION}\""  copilot/fsd-${{ inputs.app_name }}/manifest.yml
 
     - name: Run database migrations
       if: ${{ inputs.db_name != '' }}

--- a/scripts/aws_connect_db.sh
+++ b/scripts/aws_connect_db.sh
@@ -12,6 +12,7 @@ usage()
     echo "                               fsd-fund-store"
     echo "                               fsd-fund-application-builder"
     echo "                               post-award"
+    echo "                               fsd-pre-award-stores"
     echo 
 }
 
@@ -36,6 +37,7 @@ case $SERVICE in
     fsd-fund-store)                 LPORT=1436;;
     post-award)                     LPORT=1437;;
     fsd-fund-application-builder)   LPORT=1438;;
+    fsd-pre-award-stores)           LPORT=1439;;
     *)                     echo;echo "INVALID SERVICE!";usage;exit 1;;
 esac
 
@@ -75,8 +77,9 @@ then
 fi
 
 echo "Getting secret..."
-if [[ "$SERVICE" == "post-award" ]]; then
-  ARN=$(aws secretsmanager list-secrets --query "SecretList[?Tags[?Key=='aws:cloudformation:logical-id' && Value=='postawardclusterAuroraSecret']].ARN" | jq -r '.[0]')
+if [[ "$SERVICE" == "post-award" || "$SERVICE" == "fsd-pre-award-stores" ]]; then
+  VALUE="${SERVICE//-/}clusterAuroraSecret"
+  ARN=$(aws secretsmanager list-secrets --query "SecretList[?Tags[?Key=='aws:cloudformation:logical-id' && Value=='${VALUE}']].ARN" | jq -r '.[0]')
 else
   ARN=$(aws secretsmanager list-secrets --query "SecretList[?Tags[?Key=='copilot-service' && Value=='${SERVICE}']].ARN" | jq -r '.[0]')
 fi


### PR DESCRIPTION
Updates AWS deployment workflows:

- Removes hardcoded `fsd-`/`funding-service-design` prefix
- Passes and injects full built image location
- Removes ambiguity around database URL for unit tests
- Adds line to `init` a service if it's the first time it's getting deployed
- Update `aws_connect_db.sh` script to add `pre-award-stores` as an option