### PR TITLE
Update fund-store URL for combined pre-award-stores

### DIFF
--- a/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
+++ b/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
@@ -64,7 +64,7 @@ Resources:
           FUND_ROUNDS_ENDPOINT: /funds/{fund_id}/rounds
           FUND_EVENTS_ENDPOINT: /funds/{fund_id}/rounds/{round_id}/events
           FUND_EVENT_ENDPOINT: /funds/{fund_id}/rounds/{round_id}/event/{event_id}
-          FUND_STORE_API_HOST: !Sub http://fsd-fund-store.${Env}.pre-award.local:8080
+          FUND_STORE_API_HOST: !Sub http://fsd-pre-award-stores.${Env}.pre-award.local:8080/fund
           NOTIFICATION_SERVICE_API_HOST: !Sub http://fsd-notification.${Env}.pre-award.local:8080
           NOTIFY_TEMPLATE_APPLICATION_DEADLINE_REMINDER: APPLICATION_DEADLINE_REMINDER
           NOTIFY_TEMPLATE_INCOMPLETE_APPLICATION: INCOMPLETE_APPLICATION_RECORDS


### PR DESCRIPTION
We are migrating from a bunch of "microservice"-y pre-award API services to a single combined "pre-award-stores" API.

After we've migrated, we need to point all apps/lambdas/services/etc to the new service, and the fund-store API endpoints have now been namespaced under a /fund prefix.

All of the other apps will read the fund-store host from an AWS parameter store thing, but lambdas aren't able to read this in the same way - they would be expected to retrieve the value at runtime.

I don't want to change the code to support this, and since this is the only outlier I'm going to take the simplest approach - just update the fund store host in a PR. We can manage this manually as we do the migration/switchover on the day.