### PR TITLE
BAU: Update basic auth

### DIFF
--- a/.github/workflows/just-run-tests.yml
+++ b/.github/workflows/just-run-tests.yml
@@ -34,13 +34,6 @@ jobs:
     if: ${{ always() && inputs.dev == true }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
-      perf_test_target_url_application_store: http://fsd-application-store:8080
-      perf_test_target_url_fund_store: https://fsd-fund-store:8080
-      perf_test_target_url_assessment_store: https://fsd-assessment-store:8080
-      e2e_tests_target_url_frontend: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@frontend.dev.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_authenticator: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@authenticator.dev.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_form_runner: https://forms.dev.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_assessment: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@assessment.dev.access-funding.test.levellingup.gov.uk
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
@@ -48,18 +41,13 @@ jobs:
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+      FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
+      FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
 
   run_shared_tests_test:
     if: ${{ always() && inputs.test == true }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
-      perf_test_target_url_application_store: http://fsd-application-store:8080
-      perf_test_target_url_fund_store: https://fsd-fund-store:8080
-      perf_test_target_url_assessment_store: https://fsd-assessment-store:8080
-      e2e_tests_target_url_frontend: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@frontend.test.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_authenticator: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@authenticator.test.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_form_runner: https://forms.test.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_assessment: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@assessment.test.access-funding.test.levellingup.gov.uk
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
@@ -67,18 +55,13 @@ jobs:
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+      FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
+      FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
 
   run_shared_tests_uat:
     if: ${{ always() && inputs.uat == true }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
-      perf_test_target_url_application_store: http://fsd-application-store:8080
-      perf_test_target_url_fund_store: https://fsd-fund-store:8080
-      perf_test_target_url_assessment_store: https://fsd-assessment-store:8080
-      e2e_tests_target_url_frontend: https://frontend.uat.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_authenticator: https://authenticator.uat.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_form_runner: https://forms.uat.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_assessment: https://assessment.uat.access-funding.test.levellingup.gov.uk
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -100,13 +100,6 @@ jobs:
     concurrency: run_shared_tests_aws
     uses: ./.github/workflows/run-shared-tests.yml
     with:
-      perf_test_target_url_application_store: http://fsd-application-store:8080
-      perf_test_target_url_fund_store: https://fsd-fund-store:8080
-      perf_test_target_url_assessment_store: https://fsd-assessment-store:8080
-      e2e_tests_target_url_frontend: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@frontend.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_authenticator: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@authenticator.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_form_runner: https://fsd:fsd@forms.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk
-      e2e_tests_target_url_assessment: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@assessment.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk
       # run_performance_tests: ${{inputs.run_performance_tests}}
       run_performance_tests: false
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -47,6 +47,10 @@ on:
         required: true
       FSD_GH_APP_KEY:
         required: true
+      FS_BASIC_AUTH_USERNAME:
+        required: true
+      FS_BASIC_AUTH_PASSWORD:
+        required: true
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -111,6 +115,8 @@ jobs:
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
+      FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
+      FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
 
   static_security_python:
     if: ${{ inputs.run_static_security_python == true}}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -58,7 +58,10 @@ on:
         required: true
       FSD_GH_APP_KEY:
         required: true
-
+      FS_BASIC_AUTH_USERNAME:
+        required: true
+      FS_BASIC_AUTH_PASSWORD:
+        required: true
 
 jobs:
   run_application_e2e_test:
@@ -97,12 +100,12 @@ jobs:
       - name: Run E2E Tests Application For All Funds
         run: npx wdio run ./wdio.conf_headless.js
         env:
-          TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
+          TARGET_URL_FRONTEND: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@frontend.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
           EXCLUDE_ASSESSMENT: true
           EXCLUDE_APPLICATION: false
-          TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
-          TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
-          TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
+          TARGET_URL_AUTHENTICATOR: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@authenticator.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
+          TARGET_URL_FORM_RUNNER: https://fsd:fsd@forms.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
+          TARGET_URL_ASSESSMENT: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORDz }}@assessment.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
       - name: Upload E2E Test Report Application
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -146,12 +149,12 @@ jobs:
       - name: Run E2E Tests Assessment For All Funds
         run:  npx wdio run wdio.conf_headless.js
         env:
-          TARGET_URL_FRONTEND: ${{inputs.e2e_tests_target_url_frontend}}
+          TARGET_URL_FRONTEND: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@frontend.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
           EXCLUDE_ASSESSMENT: false
           EXCLUDE_APPLICATION: true
-          TARGET_URL_AUTHENTICATOR: ${{inputs.e2e_tests_target_url_authenticator}}
-          TARGET_URL_FORM_RUNNER: ${{inputs.e2e_tests_target_url_form_runner}}
-          TARGET_URL_ASSESSMENT: ${{inputs.e2e_tests_target_url_assessment}}
+          TARGET_URL_AUTHENTICATOR: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@authenticator.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
+          TARGET_URL_FORM_RUNNER: https://fsd:fsd@forms.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
+          TARGET_URL_ASSESSMENT: https://${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}@assessment.${{ inputs.env_name }}.access-funding.test.levellingup.gov.uk
       - name: Upload Assessment E2E Test Report
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -197,9 +200,9 @@ jobs:
         run: uv sync
       - name: Run performance tests
         env:
-          TARGET_URL_FUND_STORE: ${{inputs.perf_test_target_url_fund_store}}
-          TARGET_URL_APPLICATION_STORE: ${{inputs.perf_test_target_url_application_store}}
-          TARGET_URL_ASSESSMENT_STORE: ${{inputs.perf_test_target_url_assessment_store}}
+          TARGET_URL_FUND_STORE: https://fsd-fund-store:8080
+          TARGET_URL_APPLICATION_STORE: http://fsd-application-store:8080
+          TARGET_URL_ASSESSMENT_STORE: https://fsd-assessment-store:8080
         run: uv run python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}}
       - name: Upload test report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
New basic auth username/password credentials have been added as GitHub secrets, but these secrets can't be injected directly into the `with` block of jobs, which was where they were needed.

This PR moves the whole composition of the test URLs down to the workflow that needs them, where the secrets can be injected as part of the step, and passes the relevant secrets through the workflows.

Each pre-award repo that uses these workflows will need to be updated to pass `FS_BASIC_AUTH_USERNAME` and `FS_BASIC_AUTH_PASSWORD` which are now required secrets.