### PR TITLE
Auto-remove bad pyscss dependency

### DIFF
--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -94,3 +94,62 @@ jobs:
         run: uv run python -m pytest -m "not accessibility"
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/${{ inputs.db_name }}
+
+  fix-pyscss:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Fix pyscss transitive dependencies
+        id: check-pyscss
+        run: |
+          # `uv` is incorrectly pulling in enum34+pathlib2 for pyscss (if it's installed).
+          # This breaks apps because enum34 overwrites the stdlib enum namespace.
+          # `pyscss` is a very old lib that we should move away from.
+          #
+          uv sync
+          if ! uv pip show pyscss; then
+            echo "Pyscss is not installed. Skipping the update."
+            echo "commit=false" >> "$GITHUB_OUTPUT"
+          elif uv pip show enum34; then
+            PYSCSS_VERSION=$(uv pip show pyscss | grep 'Version' | cut -d' ' -f2)
+            uv remove pyscss
+            uv add "pyscss==${PYSCSS_VERSION}"
+
+            echo "Confirm that enum34 has been removed"
+
+            if ! uv pip show enum34; then
+              echo "commit=true" >> "$GITHUB_OUTPUT";
+            else
+              echo "commit=false" >> "$GITHUB_OUTPUT";
+            fi
+          fi
+
+      - name: Commit and push
+        id: commit-and-push
+        if: steps.check-pyscss.outputs.commit == 'true'
+        run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -am "Remove enum34+pathlib2
+
+            When running in Renovate, uv is incorrectly including enum34 and pathlib2 as
+            transitive dependencies of pyscss. pyscss only requires these for python
+            versions below 3.4, but something in the dependency resolver is getting
+            this wrong.
+
+            https://github.com/astral-sh/uv/issues/9217
+
+            A fix doesn't seem to be coming imminently.
+
+            pyscss is a very old and unmaintained package that we should probably
+            look to move away from sooner or later."
+            git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When running in Renovate, uv is incorrectly including enum34 and pathlib2 as transitive dependencies of pyscss. pyscss only requires these for python versions below 3.4, but something in the dependency resolver is getting this wrong.

https://github.com/astral-sh/uv/issues/9217

A fix doesn't seem to be coming imminently.

pyscss is a very old and unmaintained package that we should probably look to move away from sooner or later.

Until then, this should stop us accidentally merging enum34 and breaking our frontend apps - or having to do manual work to remove the dep.