### PR TITLE
Limit queue access to same account

### DIFF
--- a/apps/pre-award/copilot/environments/addons/assessment-import-queue.yml
+++ b/apps/pre-award/copilot/environments/addons/assessment-import-queue.yml
@@ -41,7 +41,7 @@ Resources:
             Resource: !GetAtt AssessmentImportQueue.Arn
             Principal:
               AWS:
-                - "*"
+                - !Sub '${AWS::AccountId}'
 
 Outputs:
   AssessmentImportQueueURL:

--- a/apps/pre-award/copilot/environments/addons/notification-queue.yml
+++ b/apps/pre-award/copilot/environments/addons/notification-queue.yml
@@ -41,7 +41,7 @@ Resources:
             Resource: !GetAtt NotificationQueue.Arn
             Principal:
               AWS:
-                - "*"
+                - !Sub "${AWS::AccountId}"
 
 Outputs:
   NotificationQueueURL:


### PR DESCRIPTION
These are mistakenly globally accessible (read/write), but they should definitely not be.