### PR TITLE
OIDC auth to AWS for end to end tests

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -80,6 +80,13 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: "funding-service-design-e2e-checks"
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          aws-region: eu-west-2
+
       - name: Checkout E2E tests
         uses: actions/checkout@v4.1.1
         with:
@@ -129,6 +136,13 @@ jobs:
           private-key: ${{ secrets.FSD_GH_APP_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: "funding-service-design-e2e-checks"
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          aws-region: eu-west-2
 
       - name: Checkout E2E tests
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
The end to end tests now read secrets from AWS as needed. In order for them to do this, we need to configure AWS credentials as part of the workflow.

```
[chrome 131.0.6778.85 linux #0-2] 1) E2E test to create an application for High Street Rental Auction Fund should successfully create and submit a new application for HSRA
[chrome 131.0.6778.85 linux #0-2] Error: Region is missing
[chrome 131.0.6778.85 linux #0-2]     at async FundingServiceSecrets.getBasicAuth (/home/runner/work/funding-service-design-notification/funding-service-design-notification/funding-service-design-e2e-checks/test/secrets.js:26:34)
```