### PR TITLE
Tell github about the environment

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -68,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
+    environment: ${{ inputs.env_name }}
     if: ${{ inputs.run_e2e_tests_application == true}}
     defaults:
       run:
@@ -127,6 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
+    environment: ${{ inputs.env_name }}
     if: ${{ inputs.run_e2e_tests_assessment == true}}
     defaults:
       run:


### PR DESCRIPTION
This lets github pull the correct AWS_ACCOUNT id based on the environment.

```
Run aws-actions/configure-aws-credentials@v4
  with:
    role-to-assume: arn:aws:iam:::role/GithubCopilotDeploy
    role-session-name: __copilot_
    aws-region: eu-west-[2](https://github.com/communitiesuk/funding-service-design-notification/actions/runs/12138503705/job/33857421740#step:3:2)
    audience: sts.amazonaws.com
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Error: Could not assume role with OIDC: Request ARN is invalid
```