### PR TITLE
Deprecate old workflow inputs, prefer image_location

### DIFF
--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -10,9 +10,10 @@ on:
         type: string
       version:
         description: "DEPRECATED: Used to build `image_location`. Please prefer to provide `image_location` explicitly."
-        required: true
+        required: false
         type: string
       db_name:
+        description: "DEPRECATED: Used to build `image_location`. Please prefer to provide `image_location` explicitly."
         required: false
         type: string
         default: ''


### PR DESCRIPTION
pre-award-stores and account-store currently both build a new image using a Dockerfile, which is then deployed into ECS to run database migrations. This image differs from the one used to run the web services themselves, and is generally built in a less secure way.

For both security and speed, it's easier to re-use the image that paketo has build to run database migrations.

By deprecating these old fields, we can start switching all callers over to pass `image_location` instead, which will point at the existing paketo image.