### PR TITLE
Output the paketo image location from build step

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,6 +18,10 @@ on:
       owner:
         type: string
         required: true
+    outputs:
+      image_location:
+        description: "A URI pointing to the paketo-built image"
+        value: ${{ jobs.paketo_build.outputs.image_location }}
 
 env:
   REGISTRY: ghcr.io
@@ -27,6 +31,8 @@ jobs:
   paketo_build:
     runs-on: ubuntu-latest
     name: Packaging and building the application
+    outputs:
+      image_location: ${{ steps.build_and_publish.outputs.image_location }}
     steps:
       - uses: buildpacks/github-actions/setup-pack@v5.0.0
       - uses: actions/checkout@v4
@@ -58,6 +64,7 @@ jobs:
         run: uv run python build.py
 
       - name: Build and publish app image
+        id: build_and_publish
         run: |
           IMAGE_ID=${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}
           # Change all uppercase to lowercase
@@ -70,4 +77,8 @@ jobs:
           
           uv export --format requirements-txt --no-hashes > requirements.txt
 
-          pack build $IMAGE_ID:$VERSION --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}/buildpack-packeto-cache-image --publish
+          IMAGE_LOCATION="$IMAGE_ID:$VERSION"
+
+          pack build $IMAGE_LOCATION --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}/buildpack-packeto-cache-image --publish
+
+          echo "image_location=$IMAGE_LOCATION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This should let us pass the canonical image URI through to future jobs, rather than having to build the correct URI manually elsewhere (which could lead to synchronisation issues).