### PR TITLE
FSPT-157 Remove references to funding service design base repo

### DIFF
--- a/readmes/python-repos-ide-setup.md
+++ b/readmes/python-repos-ide-setup.md
@@ -23,7 +23,7 @@ See [confluence](https://dluhcdigital.atlassian.net/wiki/spaces/FS/pages/2188247
 ## Files involved
 - [.devcontainer](./.devcontainer/python/devcontainer.json) Contains the vs code configuration for the container, such as which docker compose files to reference, and what extensions to install in the container.
 - [docker-compose.yml](./docker-compose.yml) Details of the containers that are needed to develop this app. For fund-store it uses [Dockerfile](./Dockerfile) and a `posgtres` image.
-- [Dockerfile](./Dockerfile) Details of the image to use for the dev container, under the stage `<app-name>-dev`. Built on the [FSD base image](https://github.com/communitiesuk/funding-service-design-base), and adds this repo's requirements.txt.
+- [Dockerfile](./Dockerfile) Details of the image to use for the dev container, under the stage `<app-name>-dev`. 
 - [Optional] [compose.override.yml](./compose.override.yml) Allows overriding of properties such as exposed ports, or adding environment variables to the containers listed in `docker-compose.yml`. eg. If you want the postgres instance to be accessible from your local machine you could add the following to this file:
     ```
     services:

--- a/readmes/python-repos-paketo.md
+++ b/readmes/python-repos-paketo.md
@@ -4,18 +4,6 @@
 
 [Paketo buildpacks](https://paketo.io/)
 
-## Dependencices
-Shared requirements files are stored in [FSD Base](https://github.com/communitiesuk/funding-service-design-base) so they also need installing at build time for Paketo to pick them up. Each project that needs requirements other than the default `<project-root>/requirements.txt` should add a `project.toml` file to the root of the repo, with the following as example content:
-```
-    [_]
-    schema-version = "0.2"
-
-    [[ io.buildpacks.build.env ]]
-    # Use this section to define which requirements files from fsd-base to install during AWS paketo builds
-    name = "BP_PIP_REQUIREMENT"
-    value = "./funding-service-design-base/python-flask/requirements.txt ./funding-service-design-base/python-flask/requirements-db.txt requirements.txt"
-```
-
 ## To build locally
 ```bash
     pack build <name your image> --builder paketobuildpacks/builder:base


### PR DESCRIPTION
The [funding service design base](https://github.com/communitiesuk/funding-service-design-base) repository won't be as relevant now that are reducing the number of repositories and steering away from a microservice architecture.

It doesn't look like it was ever used in anger so remove references to it before archiving.

Of note while removing this it looks like some of these instructions will need to change as we move to a single repository - some may already be out of date so an audit might be useful as a step at the end of this work.