### PR TITLE
FSPT-190 Get the account store URI from the parameter store

### DIFF
--- a/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
+++ b/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
@@ -54,7 +54,7 @@ Resources:
       Environment:
         Variables:
           ACCOUNTS_ENDPOINT: /accounts
-          ACCOUNT_STORE_API_HOST: !Sub http://fsd-account-store.${Env}.pre-award.local:8080
+          ACCOUNT_STORE_API_HOST: !Sub http://fsd-pre-award-stores.${Env}.pre-award.local:8080/account
           APPLICATIONS_ENDPOINT: /applications
           APPLICATION_ENDPOINT: /applications/{application_id}
           APPLICATION_REMINDER_STATUS: /funds/{round_id}/application_reminder_status?status=true


### PR DESCRIPTION
Just point to the new store, this will likely become scheduled job on
the main app to reduce moving parts, fine for it to be fixed for now

Previous commit (fetching from SSM doesn't appear to be supported by the lambda resource in the addons):

~~This should allow the environment variable to be retrieved from the param store at the time that this is run.~~

~~Note that similar to an ECS task definition this will only set the environment for the lambda at the time that this is run, the lambda will then use that value unless its deployed again (which presumably happens a lot less than the apps).~~

~~If we wanted to guarantee the lambda was using the latest references to stores in the param store (unlikely as we're reducing our data stores down to one database) we could use a lambda extension layer as described in:
https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html~~

~~Disclaimer: I haven't tried this and have no idea if it even makes sense.~~