### PR TITLE
FSPT-190 Add account store to migrate script

### DIFF
--- a/scripts/_migrate-pre-award-service-functions.sh
+++ b/scripts/_migrate-pre-award-service-functions.sh
@@ -3,6 +3,7 @@
 SERVICE_NAME_FUND_STORE='fsd-fund-store'
 SERVICE_NAME_APPLICATION_STORE='fsd-application-store'
 SERVICE_NAME_ASSESSMENT_STORE='fsd-assessment-store'
+SERVICE_NAME_ACCOUNT_STORE='fsd-account-store'
 AWS_COPILOT_TAG_NAME="copilot-service"
 AWS_CLOUDFORMATION_TAG_NAME="aws:cloudformation:logical-id"
 AWS_PREAWARD_RDS_TAG_VALUE="fsdpreawardstoresclusterAuroraSecret"
@@ -417,6 +418,11 @@ function migrate_environment_variables_for_service() {
     local env_var_name="ASSESSMENT_STORE_API_HOST"
     local env_var_value="http://fsd-pre-award-stores:8080/assessment"
     local calling_services="fsd-assessment"
+    ;;
+  ${SERVICE_NAME_ACCOUNT_STORE})
+    local env_var_name="ACCOUNT_STORE_API_HOST"
+    local env_var_value="http://fsd-pre-award-stores:8080/account"
+    local calling_services="fsd-pre-award-frontend fsd-authenticator"
     ;;
   *)
     echo "Unknown service name: ${app_name}"

--- a/scripts/migrate-pre-award-service.sh
+++ b/scripts/migrate-pre-award-service.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function usage() {
-  echo "Usage: $0 -a [fsd-fund-store|fsd-application-store|fsd-assessment-store] -e [dev|test|uat|prod]"
+  echo "Usage: $0 -a [fsd-fund-store|fsd-application-store|fsd-assessment-store|fsd-account-store] -e [dev|test|uat|prod]"
 }
 
 function parse_args() {
@@ -35,7 +35,7 @@ function run_pre_award_service_migration() {
   source ./scripts/_migrate-pre-award-service-functions.sh
 
   case "${app_name}" in
-  ${SERVICE_NAME_FUND_STORE} | ${SERVICE_NAME_APPLICATION_STORE} | ${SERVICE_NAME_ASSESSMENT_STORE}) ;;
+  ${SERVICE_NAME_FUND_STORE} | ${SERVICE_NAME_APPLICATION_STORE} | ${SERVICE_NAME_ASSESSMENT_STORE} | ${SERVICE_NAME_ACCOUNT_STORE}) ;;
   *)
     usage
     exit 1


### PR DESCRIPTION
For the post-award scheduled job and pre-award application deadline reminder lambda we'll run the workflows and environment updates manually -- they'll be one off for this context and shouldn't be needed by anything else that will run this script.