### PR TITLE
Also roll pre-award-stores to pick up new account store host

### DIFF
--- a/scripts/_migrate-pre-award-service-functions.sh
+++ b/scripts/_migrate-pre-award-service-functions.sh
@@ -418,7 +418,7 @@ function migrate_environment_variables_for_service() {
   ${SERVICE_NAME_ACCOUNT_STORE})
     local env_var_name="ACCOUNT_STORE_API_HOST"
     local env_var_value="http://fsd-pre-award-stores:8080/account"
-    local calling_services="fsd-pre-award-frontend fsd-authenticator"
+    local calling_services="fsd-pre-award-frontend fsd-authenticator fsd-pre-award-stores"
     ;;
   *)
     echo "Unknown service name: ${app_name}"


### PR DESCRIPTION
pre-award-stores also reads the ACCOUNT_STORE_API_HOST value from parameter store, so we need to roll that service after changing it before disabling maintenance mode.