### PR TITLE
Make python e2e tests only run in dev+test

### DIFF
--- a/.github/workflows/just-run-tests.yml
+++ b/.github/workflows/just-run-tests.yml
@@ -75,7 +75,7 @@ jobs:
       run_performance_tests: ${{inputs.run_performance_tests}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
-      run_e2e_tests_python: ${{inputs.run_e2e_tests_python}}
+      run_e2e_tests_python: false  # these tests don't work in UAT env
       env_name: uat
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -106,6 +106,7 @@ jobs:
       run_performance_tests: false
       run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
       run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
+      run_e2e_tests_python: ${{ inputs.environment == 'dev' || inputs.environment == 'test' }}
       env_name: ${{inputs.environment}}
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}


### PR DESCRIPTION
These tests do not work in the UAT environment.