### PR TITLE
Enable slack notifications for failed deploy

### DIFF
--- a/.github/workflows/notify-slack-deployment-failed.yml
+++ b/.github/workflows/notify-slack-deployment-failed.yml
@@ -1,0 +1,115 @@
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        required: true
+        type: string
+      env_name:
+        required: true
+        type: string
+      github_username:
+        required: true
+        type: string
+      workflow_url:
+        required: true
+        type: string
+      compare_url:
+        required: false
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+      SLACK_NOTIFICATION_CHANNEL_ID:
+        required: true
+
+jobs:
+  notify_slack:
+    if: ${{ inputs.compare_url != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send message to Slack (push)
+        if: ${{ github.event_name == 'push' }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+            text: test notification
+            blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: ":x: A deployment has failed - please investigate :x:"
+            - type: section
+              fields:
+              - type: mrkdwn
+                text: |-
+                  *App:*
+                  ${{ inputs.app_name }}
+              - type: mrkdwn
+                text: |-
+                  *Environment:*
+                  ${{ inputs.env_name }}
+              - type: mrkdwn
+                text: |-
+                  *Commit author:*
+                  ${{ inputs.github_username }}
+              - type: mrkdwn
+                text: |-
+                  *Triggered by:*
+                  Merged pull request
+            - type: actions
+              elements:
+                - type: button
+                  text:
+                    type: plain_text
+                    emoji: true
+                    text: ":github: Open workflow run"
+                  url: ${{ inputs.workflow_url }}
+                - type: button
+                  text:
+                    type: plain_text
+                    emoji: true
+                    text: ":merged: View code changes"
+                  url: ${{ inputs.compare_url }}
+      - name: Send message to Slack (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+            text: test notification
+            blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: ":x: A deployment has failed - please investigate :x:"
+            - type: section
+              fields:
+              - type: mrkdwn
+                text: |-
+                  *App:*
+                  ${{ inputs.app_name }}
+              - type: mrkdwn
+                text: |-
+                  *Environment:*
+                  ${{ inputs.env_name }}
+              - type: mrkdwn
+                text: |-
+                  *Commit author:*
+                  ${{ inputs.github_username }}
+              - type: mrkdwn
+                text: |-
+                  *Triggered by:*
+                  Manual workflow run
+            - type: actions
+              elements:
+                - type: button
+                  text:
+                    type: plain_text
+                    emoji: true
+                    text: ":github: Open workflow run"
+                  url: ${{ inputs.workflow_url }}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -41,6 +41,10 @@ on:
         required: false
         default: false
         type: boolean
+      notify_slack:
+        required: true
+        default: false
+        type: boolean
 
     secrets:
       FSD_GH_APP_ID:
@@ -52,6 +56,10 @@ on:
       FS_BASIC_AUTH_PASSWORD:
         required: true
       AWS_ACCOUNT:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+      SLACK_NOTIFICATION_CHANNEL_ID:
         required: true
 
   # Allows you to run this workflow manually from the Actions tab
@@ -152,3 +160,20 @@ jobs:
         with:
           target: "https://${{inputs.app_name}}.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk/"
           allow_issue_writing: False
+
+  notify_slack:
+    needs:
+      - run_shared_tests_aws
+      - static_security_python
+      - zap-scan-aws
+    if: ${{ inputs.notify_slack && always() && (needs.run_shared_tests_aws.result == 'failure' || needs.static_security_python.result == 'failure' || needs.zap-scan-aws.result == 'failure' || needs.run_performance_tests.result == 'failure') }}
+    uses: ./.github/workflows/notify-slack-deployment-failed.yml
+    with:
+      app_name: ${{ inputs.app_name }}
+      env_name: ${{ inputs.environment }}
+      github_username: ${{ github.actor }}
+      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -58,9 +58,9 @@ on:
       AWS_ACCOUNT:
         required: true
       SLACK_BOT_TOKEN:
-        required: true
+        required: false
       SLACK_NOTIFICATION_CHANNEL_ID:
-        required: true
+        required: false
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -57,6 +57,9 @@ on:
       env_name:
         required: true
         type: string
+      app_name:
+        required: false
+        type: string
     secrets:
       FSD_GH_APP_ID:
         required: true

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -16,10 +16,17 @@ on:
         description: "Location of the image to deploy."
         type: string
         required: false
+      notify_slack:
+        required: true
+        default: false
+        type: boolean
     secrets:
       AWS_ACCOUNT:
         required: true
-
+      SLACK_BOT_TOKEN:
+        required: true
+      SLACK_NOTIFICATION_CHANNEL_ID:
+        required: true
 jobs:
   deploy:
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -77,3 +84,18 @@ jobs:
       run: |
         copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
         copilot svc deploy --env ${{ inputs.environment }} --app pre-award
+
+  notify_slack:
+    needs:
+      - deploy
+    if: ${{ inputs.notify_slack && always() && needs.deploy.result == 'failure' }}
+    uses: ./.github/workflows/notify-slack-deployment-failed.yml
+    with:
+      app_name: ${{ inputs.app_name }}
+      env_name: ${{ inputs.environment }}
+      github_username: ${{ github.actor }}
+      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}


### PR DESCRIPTION
When a deployment pipeline fails, we've seen developers not quickly notice and own getting it resolved.

This patch integrates a Slack Workflow that the github action can call which will send a chat message to one of our dev channels.

<img width="546" alt="image" src="https://github.com/user-attachments/assets/3d44d85c-7c81-4543-941c-8a8de39c5c09" />

I wanted to have the app `@tag` the user in slack who committed the code/ran the workflow, but doing the lookup from github actor -> slack user is not a super reliable lookup, so I haven't bothered. It might be a nice addition in the future though.

## Todo
See todo list in comment on ticket: https://mhclgdigital.atlassian.net/browse/FSPT-220. PRs need to be merged around the same time, and there are some pre-reqs that need to be done by a github/slack admin.