### PR TITLE
Don't require slack secrets on standard-deploy

### DIFF
--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -24,9 +24,9 @@ on:
       AWS_ACCOUNT:
         required: true
       SLACK_BOT_TOKEN:
-        required: true
+        required: false
       SLACK_NOTIFICATION_CHANNEL_ID:
-        required: true
+        required: false
 jobs:
   deploy:
     if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
We don't notify to slack on failed dev deploys, so the secrets are optional.