### PR TITLE
BAU: Add app_name variable to copilot deploy command

### DIFF
--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -83,7 +83,7 @@ jobs:
       id: deploy_build
       run: |
         copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
-        copilot svc deploy --env ${{ inputs.environment }} --app pre-award
+        copilot svc deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
 
   notify_slack:
     needs:


### PR DESCRIPTION
This is to avoid a case where jobs are deployed with a matrix or similar names and the copilot command can't determine which service to deploy without it being specified.