### PR TITLE
Don't require compare_url

### DIFF
--- a/.github/workflows/notify-slack-deployment-failed.yml
+++ b/.github/workflows/notify-slack-deployment-failed.yml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   notify_slack:
-    if: ${{ inputs.compare_url != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if deployment was manually rejected


### PR DESCRIPTION
It's OK for this to be unset - it's only required on push events.