### PR TITLE
Always tag latest for built images

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,6 +79,6 @@ jobs:
 
           IMAGE_LOCATION="$IMAGE_ID:$VERSION"
 
-          pack build $IMAGE_LOCATION --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}/buildpack-packeto-cache-image --publish
+          pack build $IMAGE_LOCATION --tag $IMAGE_ID:latest --builder paketobuildpacks/builder-jammy-full --cache-image ${{ env.REGISTRY }}/${{ inputs.owner }}/${{ env.DOCKER_IMAGE }}/buildpack-packeto-cache-image --publish
 
           echo "image_location=$IMAGE_LOCATION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This is so that we have an easier reference to use for eg pulling locally to inspect images.

From `pack build --help`:

  -t, --tag strings                  Additional tags to push the output
image to. Tags should be in the format 'image:tag' or
'repository/image:tag'. Repeat for each tag in order, or supply once by
comma-separated list