### PR TITLE
BAU: fix help text to reflect accepted value

### DIFF
--- a/scripts/aws_connect_db.sh
+++ b/scripts/aws_connect_db.sh
@@ -10,7 +10,7 @@ usage() {
   echo "                               fsd-assessment-store"
   echo "                               fsd-fund-store"
   echo "                               fsd-fund-application-builder"
-  echo "                               fsd-pre-award"
+  echo "                               fsd-pre-award-stores"
   echo "                               post-award"
   echo
 }


### PR DESCRIPTION
Spotted in the course of other work

## How to text

`./scripts/aws_connect_db.sh` should show help text

`./scripts/aws_connect_db.sh fsd-pre-award-stores` should connect to DB successfully (if auth'd with aws-vault)