### PR TITLE
Install requests on github actions deploy

### DIFF
--- a/.github/workflows/update-preaward-env.yml
+++ b/.github/workflows/update-preaward-env.yml
@@ -46,6 +46,11 @@ jobs:
     - name: Git clone the repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+    - name: Install requests library
+      working-directory: 'apps/pre-award/lambdas/application-deadline-reminder'
+      run: |
+        python -m pip install requests --target .
+
     - name: Setup Copilot
       uses: ./.github/actions/copilot_setup
       with:

--- a/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
+++ b/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
@@ -88,7 +88,6 @@ Resources:
             - ','
             - Fn::ImportValue: !Sub ${App}-${Env}-PrivateSubnets
       Layers:
-        - arn:aws:lambda:eu-west-2:378673660975:layer:python-modules:1
         - arn:aws:lambda:eu-west-2:943013980633:layer:SentryPythonServerlessSDK:138
         
 


### PR DESCRIPTION
AWS lambda doesn't provide the requests library out of the box. As a result, we package the requests library as part of the (Github actions) deployment of the lambda to ensure it includes all necessary dependencies (the alternative is to create a lambda layer - this is a very similar process but would require a manual step in uploading the requests library to S3). 