### PR TITLE
Post messages when deployments (to prod) start and end

### DIFF
--- a/.github/actions/slack_deployment_message/action.yml
+++ b/.github/actions/slack_deployment_message/action.yml
@@ -1,0 +1,96 @@
+name: "Notify Slack of deployment started"
+
+inputs:
+  stage:
+    description: "Determines the message sent to slack; valid options are only `start` or `end`."
+    required: true
+  app_name:
+    description: "The app being deployed."
+    required: true
+  environment:
+    description: "Copilot environment to deploy to."
+    required: true
+  workflow_url:
+    description: "The github actions workflow URL for the deployment."
+    required: true
+  slack_bot_token:
+    description: Slack bot token (secret)
+    required: true
+  slack_channel_id:
+    description: The Slack channel ID to post the message in
+    required: true
+
+  status:
+    description: "[required if stage=end] The description for the final deployment status; valid options are only `success` or `failed`."
+    required: false
+  slack_message_ts:
+    description: "[required if stage=end] The identifier returned from the Slack API for the start deployment message thread"
+    required: false
+  deployment_start_ts:
+    description: "[required if stage=end] The deployment start timestamp."
+    required: false
+
+outputs:
+  timestamp:
+    value: ${{ steps.timestamp.outputs.timestamp }}
+  slack_start_message_ts:
+    value: ${{ steps.start_message.outputs.ts }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get current time
+      id: timestamp
+      shell: bash
+      run: |
+        echo "timestamp=$(date +'%-I:%M%P')" >> $GITHUB_OUTPUT
+
+    - name: Slack message for start of deployment
+      if: ${{ inputs.stage == 'start' }}
+      id: start_message
+      uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.slack_bot_token }}
+        payload: |
+          channel: ${{ inputs.slack_channel_id }}
+          text: Deployment notification for ${{ inputs.app_name }}
+          blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: "Deployment of ${{ inputs.app_name }} to ${{ inputs.environment }} started at ${{ steps.timestamp.outputs.timestamp }}.\n\n:spinner:"
+            - type: actions
+              elements:
+                - type: button
+                  text:
+                    type: plain_text
+                    emoji: true
+                    text: ":github: Open workflow run"
+                  url: ${{ inputs.workflow_url }}
+
+
+    - name: Slack message for end of deployment
+      if: ${{ inputs.stage == 'end' }}
+      id: end_message
+      uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+      with:
+        method: chat.update
+        token: ${{ inputs.slack_bot_token }}
+        payload: |
+          channel: ${{ inputs.slack_channel_id }}
+          ts: "${{ inputs.slack_message_ts }}"
+          text: Deployment notification for ${{ inputs.app_name }}
+          blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: "Deployment of ${{ inputs.app_name }} to ${{ inputs.environment }} started at ${{ inputs.deployment_start_ts }}.\n\n${{ inputs.status == 'success' && ':white_check_mark: Completed' || ':x: Failed' }} at ${{ steps.timestamp.outputs.timestamp }}."
+            - type: actions
+              elements:
+                - type: button
+                  text:
+                    type: plain_text
+                    emoji: true
+                    text: ":github: Open workflow run"
+                  url: ${{ inputs.workflow_url }}

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -17,7 +17,12 @@ on:
         type: string
         required: false
       notify_slack:
+        description: "Sends an alert to the prod alerts channel if deployment fails"
         required: true
+        default: false
+        type: boolean
+      notify_slack_on_deployment:
+        description: "Send messages to the deployments channel when deploys start+finish."
         default: false
         type: boolean
     secrets:
@@ -26,6 +31,9 @@ on:
       SLACK_BOT_TOKEN:
         required: false
       SLACK_NOTIFICATION_CHANNEL_ID:
+        required: false
+      SLACK_DEPLOYMENTS_CHANNEL_ID:
+        description: "[required if notify_slack_on_deployment=true]"
         required: false
 jobs:
   deploy:
@@ -75,7 +83,20 @@ jobs:
       run: |
         yq -i ".image.location = \"${{ inputs.image_location }}\""  copilot/fsd-${{ inputs.app_name }}/manifest.yml
 
+    - name: Slack message for start of deployment
+      id: slack_start_deployment_message
+      if: ${{ inputs.notify_slack_on_deployment }}
+      uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
+      with:
+        stage: 'start'
+        app_name: ${{ inputs.app_name }}
+        environment: ${{ inputs.environment }}
+        workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
+
     - name: Run database migrations
+      id: db_migrations
       if: ${{ inputs.run_db_migrations }}
       run: scripts/migration-task-script.py ${{ inputs.environment }} ${{ inputs.image_location }}
 
@@ -84,6 +105,21 @@ jobs:
       run: |
         copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
         copilot svc deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
+
+    - name: Slack message for end of deployment
+      if: ${{ always() && inputs.notify_slack_on_deployment && steps.slack_start_deployment_message.outcome == 'success' }}
+      uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
+      with:
+        stage: 'end'
+        app_name: ${{ inputs.app_name }}
+        environment: ${{ inputs.environment }}
+        workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
+
+        status: "${{ ( (steps.db_migrations.outcome == 'skipped' || steps.db_migrations.outcome == 'success') && steps.deploy_build.outcome == 'success') && 'success' || 'failed' }}"
+        slack_message_ts: ${{ steps.slack_start_deployment_message.outputs.slack_start_message_ts }}
+        deployment_start_ts: ${{ steps.slack_start_deployment_message.outputs.timestamp }}
 
   notify_slack:
     needs:


### PR DESCRIPTION
Add steps to the standard deployment pipeline that post messages to a deployments slack channel to make it clear when deployments start and finish.

For now, we just do this for the production environment. This should help identify if errors are/may be related to a recent deployment.

The various messages it shows (you get 1 message per deployment, which is updated - these are just all of the various things you might see, but you wouldn't get all three visible at once). Except ignore the 'view code changes' link - I've removed that for all states because of faffy edge cases.
<img width="503" alt="image" src="https://github.com/user-attachments/assets/ed4c3d1e-43d1-4fe2-89c4-265dd644f713" />

## Todo
Need to add SLACK_DEPLOYMENTS_CHANNEL_ID org-level secret, add it to all the relevant repos, and raise PRs on all of those repos to pass the secret into the standard-deploy action.