### PR TITLE
FSPT-243: add redirect cloudfront function

### DIFF
--- a/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
+++ b/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
@@ -13,7 +13,7 @@ Mappings:
     test:
       "DomainSuffix": ".test.access-funding.communities.gov.uk"
     uat:
-      "DomainSuffix": ".uat.access-funding.communities.gov.uk."
+      "DomainSuffix": ".uat.access-funding.communities.gov.uk"
     prod:
       "DomainSuffix": ".access-funding.communities.gov.uk"
   

--- a/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
+++ b/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
@@ -1,0 +1,72 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+
+Mappings:
+  DomainSuffixMap:
+    dev:
+      "DomainSuffix": ".dev.access-funding.communities.gov.uk"
+    test:
+      "DomainSuffix": ".test.access-funding.communities.gov.uk"
+    uat:
+      "DomainSuffix": ".uat.access-funding.communities.gov.uk."
+    prod:
+      "DomainSuffix": ".access-funding.communities.gov.uk"
+  
+Resources:
+  CommunitiesRedirect:
+    Type: 'AWS::CloudFront::Function'
+    Properties:
+      Name: CommunitiesRedirect
+      AutoPublish: true
+      FunctionCode: !Sub
+      - |
+        function handler(event) {
+          const host = event.request.headers.host.value;
+          const uri = event.request.uri;
+          
+          var newUrl;
+          // renamed services
+          if (host.startsWith('frontend.') && host.endsWith('.levellingup.gov.uk'))
+              newUrl = `https://apply${DomainSuffix}${!uri}`;
+          else if (host.startsWith('authenticator.') && host.endsWith('.levellingup.gov.uk'))
+              newUrl = `https://account${DomainSuffix}${!uri}`;
+          else if (host.startsWith('assessment.') && host.endsWith('.levellingup.gov.uk'))
+            newUrl = `https://assess${DomainSuffix}${!uri}`;
+          else if (host.startsWith('forms.') && host.endsWith('levellingup.gov.uk'))
+            newUrl = `https://application-questions${DomainSuffix}${!uri}`;
+          // unchanged named services
+          else if (host.endsWith('.levellingup.gov.uk')) {
+            const serviceHostName = host.split('.')[0]
+            newUrl = `${!serviceHostName}${DomainSuffix}${!uri}`
+          }
+          else {
+          // non-legacy domain pass through unchanged request
+              return event.request
+          }
+          // TODO: Switch to 301 when we are sure this is working as intended
+          var response = {
+              statusCode: 302,
+              statusDescription: "Found",
+              headers: {
+                  "location": {
+                      value: newUrl,
+                  },
+              },
+          };
+            return response;
+        }
+      - DomainSuffix: !FindInMap [DomainSuffixMap, !Ref Env, 'DomainSuffix']
+      FunctionConfig: 
+        Comment: Redirects to the communities.gov.uk domains
+        Runtime: cloudfront-js-2.0
+Outputs:
+  CommunitiesRedirectArn:
+    Description: The ARN of the CloudFront function.
+    Value: !GetAtt CommunitiesRedirect.FunctionARN
+    Export:
+      Name: CommunitiesRedirectArn

--- a/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
+++ b/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
@@ -27,26 +27,27 @@ Resources:
       - |
         function handler(event) {
           const host = event.request.headers.host.value;
-          const uri = event.request.uri;
           
+          // non-legacy domain pass through unchanged request
+          if (host.endsWith('.communities.gov.uk')) {
+            return event.request
+          }
+          
+          const uri = event.request.uri;
           var newUrl;
-          // renamed services
-          if (host.startsWith('frontend.') && host.endsWith('.levellingup.gov.uk'))
+          // Redirect renamed levellingup domains
+          if (host.startsWith('frontend.'))
               newUrl = `https://apply${DomainSuffix}${!uri}`;
-          else if (host.startsWith('authenticator.') && host.endsWith('.levellingup.gov.uk'))
+          else if (host.startsWith('authenticator.'))
               newUrl = `https://account${DomainSuffix}${!uri}`;
-          else if (host.startsWith('assessment.') && host.endsWith('.levellingup.gov.uk'))
+          else if (host.startsWith('assessment.'))
             newUrl = `https://assess${DomainSuffix}${!uri}`;
-          else if (host.startsWith('forms.') && host.endsWith('levellingup.gov.uk'))
+          else if (host.startsWith('forms.'))
             newUrl = `https://application-questions${DomainSuffix}${!uri}`;
-          // unchanged named services
-          else if (host.endsWith('.levellingup.gov.uk')) {
+          // unchanged name levellingup services
+          else  {
             const serviceHostName = host.split('.')[0]
             newUrl = `${!serviceHostName}${DomainSuffix}${!uri}`
-          }
-          else {
-          // non-legacy domain pass through unchanged request
-              return event.request
           }
           // TODO: Switch to 301 when we are sure this is working as intended
           var response = {

--- a/apps/pre-award/copilot/environments/overrides/README.md
+++ b/apps/pre-award/copilot/environments/overrides/README.md
@@ -1,0 +1,17 @@
+# Overriding Copilot generated CloudFormation templates with YAML Patches
+
+The file `cfn.patches.yml` contains a list of YAML/JSON patches to apply to
+your template before AWS Copilot deploys it.
+
+To view examples and an explanation of how YAML patches work, check out the [documentation](https://aws.github.io/copilot-cli/docs/developing/overrides/yamlpatch).
+
+Note only [`add`](https://www.rfc-editor.org/rfc/rfc6902#section-4.1),
+[`remove`](https://www.rfc-editor.org/rfc/rfc6902#section-4.2), and
+[`replace`](https://www.rfc-editor.org/rfc/rfc6902#section-4.3)
+operations are supported by Copilot.
+Patches are applied in the order specified in the file.
+
+## Troubleshooting
+
+* `copilot [noun] package` preview the transformed template by writing to stdout.
+* `copilot [noun] package --diff` show the difference against the template deployed in your environment.

--- a/apps/pre-award/copilot/environments/overrides/cfn.patches.yml
+++ b/apps/pre-award/copilot/environments/overrides/cfn.patches.yml
@@ -1,0 +1,22 @@
+# Delete the task role resource
+# - op: remove
+#   path: /Resources/TaskRole
+
+# Add a service connect alias
+# - op: add
+#   path: /Resources/Service/Properties/ServiceConnectConfiguration/Services/0/ClientAliases/-
+#   value:
+#     Port: !Ref TargetPort
+#     DnsName: yamlpatchiscool
+
+# Replace the task role in the task definition
+# - op: replace
+#   path: /Resources/TaskDefinition/Properties/TaskRoleArn
+#   value: arn:aws:iam::123456789012:role/MyTaskRole
+
+# TODO: Uncomment this to enable domain redirects
+# - op: add
+#   path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/DefaultCacheBehavior/FunctionAssociations
+#   value: 
+#     - EventType: viewer-request 
+#       FunctionARN: !ImportValue CommunitiesRedirectArn


### PR DESCRIPTION
Adds a cloudfront function to support domain name move

* Redirect to renamed communities.gov.uk services
* Redirect to un-renamed communities.gov.uk services
* passthrough any other requests

N.B. Weird interpolation syntax is due to mixing AWS and Javascript interpolation, syntax is as described in: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html#w32aac23c24c67b7

## How to test
Deploying this branch should create a Cloudfront Function
This can then be tested using the Test function in the Cloudfront Functions console by setting the host header for the scenario under test.

I have also tested by deploying on dev with the function association temporarily.