### PR TITLE
add env artifact name

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           target: "https://${{inputs.app_name}}.${{ inputs.environment }}.access-funding.test.levellingup.gov.uk/"
           allow_issue_writing: False
+          artifact_name: zap-scan-${{ inputs.environment }}
 
   notify_slack:
     needs:


### PR DESCRIPTION
So that we can upload an artifact for test and uat without it complaining about overlapping names.

<img width="1217" alt="image" src="https://github.com/user-attachments/assets/e913281d-dcf2-4de6-93e6-17e1703d5047" />
