### PR TITLE
Allow deploying scheduled jobs as well as services

### DIFF
--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -44,7 +44,7 @@ jobs:
   deploy:
     if: ${{ github.actor != 'dependabot[bot]' }}
     concurrency:
-      group: 'fsd-preaward-${{ inputs.environment }}'
+      group: 'fsd-preaward-${{ inputs.environment }}-${{ inputs.app_name }}'
       cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -5,6 +5,11 @@ on:
       app_name:
         required: false
         type: string
+      deploy_type:
+        required: false
+        default: svc
+        type: string
+        description: "Copilot noun for deploying, expects `job` or `svc`"
       environment:
         required: true
         type: string
@@ -103,8 +108,8 @@ jobs:
     - name: Copilot ${{ inputs.environment }} deploy
       id: deploy_build
       run: |
-        copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
-        copilot svc deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
+        copilot ${{ inputs.deploy_type }} init --app pre-award --name fsd-${{ inputs.app_name }}
+        copilot ${{ inputs.deploy_type }} deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
 
     - name: Slack message for end of deployment
       if: ${{ always() && inputs.notify_slack_on_deployment && steps.slack_start_deployment_message.outcome == 'success' }}

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -80,13 +80,11 @@ jobs:
           exit 1
         fi
 
-    - name: Inject Git SHA into manifest
+    - name: Update manifest
       run: |
         yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/fsd-${{ inputs.app_name }}/manifest.yml
-
-    - name: Inject replacement image into manifest
-      run: |
         yq -i ".image.location = \"${{ inputs.image_location }}\""  copilot/fsd-${{ inputs.app_name }}/manifest.yml
+        yq -i "del(.image.build)"  copilot/fsd-${{ inputs.app_name }}/manifest.yml
 
     - name: Slack message for start of deployment
       id: slack_start_deployment_message

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Copilot ${{ inputs.environment }} deploy
       id: deploy_build
       run: |
-        copilot ${{ inputs.deploy_type }} init --app pre-award --name fsd-${{ inputs.app_name }}
+        copilot ${{ inputs.deploy_type }} init --app pre-award --name fsd-${{ inputs.app_name }} || true
         copilot ${{ inputs.deploy_type }} deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
 
     - name: Slack message for end of deployment


### PR DESCRIPTION
We need to start deploying scheduled jobs for the pre-award repo (to send application deadline reminders: https://github.com/communitiesuk/funding-service-pre-award/pull/243).

This adds another optional parameter to the deployment workflow so that we can toggle between copilot deploying services (long-running apps) and jobs (one-off tasks).

It also tweaks the concurrency groups so that different copilot entities are able to deploy at the same time. This affects both the new job for pre-award, and the existing form-runner/form-designer deploys (which are currently sequential but don't need to be).