### PR TITLE
FSPT-250: Remove Fund Store cluster Security group from lambda

### DIFF
--- a/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
+++ b/apps/pre-award/copilot/environments/addons/application-deadline-reminder.yml
@@ -88,7 +88,6 @@ Resources:
           SENTRY_TRACES_SAMPLE_RATE: 1
       VpcConfig:
         SecurityGroupIds:
-          - Fn::ImportValue: "fsdfundstoreclusterSecurityGroup"
           - Fn::ImportValue: !Sub ${App}-${Env}-InternalLoadBalancerSecurityGroup
           - Fn::ImportValue: !Sub ${App}-${Env}-EnvironmentSecurityGroup
         SubnetIds:


### PR DESCRIPTION
This security group grants direct access to the Fund Store database so we don't believe it is required by the Lambda. We have also run the Lambda on dev without this permission in the console without any change in behaviour observed.