### PR TITLE
FSPT-228: hard code certificate in Dev

### DIFF
--- a/apps/pre-award/copilot/environments/dev/manifest.yml
+++ b/apps/pre-award/copilot/environments/dev/manifest.yml
@@ -29,7 +29,7 @@ observability:
   container_insights: false
 
 cdn: 
-  certificate: arn:aws:acm:eu-west-2:012986738649:certificate/44c63000-e875-4e9a-914a-c6d3f33a6347
+  certificate: arn:aws:acm:us-east-1:012986738649:certificate/1a6910a4-6ba9-401e-be69-d0709e5ea854
 
 http:
   public:

--- a/apps/pre-award/copilot/environments/dev/manifest.yml
+++ b/apps/pre-award/copilot/environments/dev/manifest.yml
@@ -35,9 +35,6 @@ http:
   public:
     certificates:
       - arn:aws:acm:eu-west-2:012986738649:certificate/464a3953-0dd4-49bd-9a99-4531910908f0
-
-http:
-  public:
     security_groups:
       ingress:
         restrict_to:

--- a/apps/pre-award/copilot/environments/dev/manifest.yml
+++ b/apps/pre-award/copilot/environments/dev/manifest.yml
@@ -28,7 +28,13 @@ network:
 observability:
   container_insights: false
 
-cdn: true
+cdn: 
+  certificate: arn:aws:acm:eu-west-2:012986738649:certificate/44c63000-e875-4e9a-914a-c6d3f33a6347
+
+http:
+  public:
+    certificates:
+      - arn:aws:acm:eu-west-2:012986738649:certificate/464a3953-0dd4-49bd-9a99-4531910908f0
 
 http:
   public:


### PR DESCRIPTION
We are switching to hardcoded certificates which will be managed in Terraform. 

This allows us to add aliases from different domains.