### PR TITLE
FSPT-228: Add test, uat certificates & update prod certificates

### DIFF
--- a/.github/workflows/update-preaward-env.yml
+++ b/.github/workflows/update-preaward-env.yml
@@ -54,5 +54,7 @@ jobs:
 
     - name: Copilot deploy
       working-directory: 'apps/pre-award'
+      env:
+        AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       run: |
         copilot env deploy --name ${{ matrix.value }} --app pre-award

--- a/apps/pre-award/copilot/environments/dev/manifest.yml
+++ b/apps/pre-award/copilot/environments/dev/manifest.yml
@@ -29,12 +29,12 @@ observability:
   container_insights: false
 
 cdn: 
-  certificate: arn:aws:acm:us-east-1:012986738649:certificate/1a6910a4-6ba9-401e-be69-d0709e5ea854
+  certificate: arn:aws:acm:us-east-1:${AWS_ACCOUNT}:certificate/1a6910a4-6ba9-401e-be69-d0709e5ea854
 
 http:
   public:
     certificates:
-      - arn:aws:acm:eu-west-2:012986738649:certificate/464a3953-0dd4-49bd-9a99-4531910908f0
+      - arn:aws:acm:eu-west-2:${AWS_ACCOUNT}:certificate/464a3953-0dd4-49bd-9a99-4531910908f0
     security_groups:
       ingress:
         restrict_to:

--- a/apps/pre-award/copilot/environments/prod/manifest.yml
+++ b/apps/pre-award/copilot/environments/prod/manifest.yml
@@ -29,12 +29,12 @@ observability:
   container_insights: false
 
 cdn:
-  certificate: "arn:aws:acm:us-east-1:233700139423:certificate/8219780e-91bb-4eb8-8292-452aa8749d00"
+  certificate: "arn:aws:acm:us-east-1:${AWS_ACCOUNT}:certificate/a6c9df88-856a-4a81-a3a1-f296b1e32da8"
 
 http:
   public:
     certificates:
-      - arn:aws:acm:eu-west-2:233700139423:certificate/12a7047c-c3f2-49d6-8dbe-3f784daddcd6
+      - arn:aws:acm:eu-west-2:${AWS_ACCOUNT}:certificate/307c8df7-04b7-4819-8b25-52f5bf97bddd
     security_groups:
       ingress:
         restrict_to:

--- a/apps/pre-award/copilot/environments/test/manifest.yml
+++ b/apps/pre-award/copilot/environments/test/manifest.yml
@@ -29,10 +29,13 @@ network:
 observability:
   container_insights: false
 
-cdn: true
+cdn:
+  certificate: arn:aws:acm:us-east-1:${AWS_ACCOUNT}:certificate/0b36c804-8a79-4d56-a614-18279add284d
 
 http:
   public:
+    certificates:
+      - arn:aws:acm:eu-west-2:${AWS_ACCOUNT}:certificate/d2552a1d-9956-4841-8112-7a491a51c02a
     security_groups:
       ingress:
         restrict_to:

--- a/apps/pre-award/copilot/environments/uat/manifest.yml
+++ b/apps/pre-award/copilot/environments/uat/manifest.yml
@@ -29,10 +29,13 @@ network:
 observability:
   container_insights: false
 
-cdn: true
+cdn:
+  certificate: arn:aws:acm:us-east-1:${AWS_ACCOUNT}:certificate/3c5e0bbc-9529-453d-b1b9-7f95b250a63b
 
 http:
   public:
+    certificates:
+      - arn:aws:acm:eu-west-2:${AWS_ACCOUNT}:certificate/d4d18aaf-9844-4b6d-8fa8-23f993a08846
     security_groups:
       ingress:
         restrict_to:


### PR DESCRIPTION
Adds certificates to support domain migration 

(also refactors to use [variable substitution](https://aws.github.io/copilot-cli/docs/developing/manifest-env-var/) for account id)

I have verified these certicates have been validated successfully in the console, so should attach to the resources successfully in each environment