### PR TITLE
FSPT-228: enable redirect cloudfront function

### DIFF
--- a/apps/pre-award/copilot/environments/overrides/cfn.patches.yml
+++ b/apps/pre-award/copilot/environments/overrides/cfn.patches.yml
@@ -14,9 +14,8 @@
 #   path: /Resources/TaskDefinition/Properties/TaskRoleArn
 #   value: arn:aws:iam::123456789012:role/MyTaskRole
 
-# TODO: Uncomment this to enable domain redirects
-# - op: add
-#   path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/DefaultCacheBehavior/FunctionAssociations
-#   value: 
-#     - EventType: viewer-request 
-#       FunctionARN: !ImportValue CommunitiesRedirectArn
+- op: add
+  path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/DefaultCacheBehavior/FunctionAssociations
+  value: 
+    - EventType: viewer-request 
+      FunctionARN: !ImportValue CommunitiesRedirectArn


### PR DESCRIPTION
Enables the Cloudfront Redirect function added in https://github.com/communitiesuk/funding-service-design-workflows/pull/266

N.B. will disable the workflow after deployment to Test to stop it going to UAT and Production prematurely.

