### PR TITLE
FSPT-228: add protocol to redirect location in unchanged hostname case

### DIFF
--- a/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
+++ b/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
@@ -47,7 +47,7 @@ Resources:
           // unchanged name levellingup services
           else  {
             const serviceHostName = host.split('.')[0]
-            newUrl = `${!serviceHostName}${DomainSuffix}${!uri}`
+            newUrl = `https://${!serviceHostName}${DomainSuffix}${!uri}`
           }
           // TODO: Switch to 301 when we are sure this is working as intended
           var response = {


### PR DESCRIPTION
Fix the redirect function. 

Redirect location should be an absolute path. Previously this was missing from this condition causing a relative path to be returned.

Have tested this using the Cloudfront Functions test console.