### PR TITLE
BAU: Allow concurrency if app name varies

### DIFF
--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     if: ${{ github.actor != 'dependabot[bot]' }}
     concurrency:
-      group: 'fsd-preaward-${{ inputs.environment }}'
+      group: 'fsd-preaward-${{ inputs.environment }}-{{inputs.app_name}}'
       cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
Spotted in the course of another story. 

This allows the different form-adapter services to deploy in parallel