### PR TITLE
BAU: Fix typos and syntax errors in deploy workflow

### DIFF
--- a/.github/workflows/list-versions.yml
+++ b/.github/workflows/list-versions.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
       with:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-        role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+        role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
         aws-region: eu-west-2
 
     - name: Install AWS Copilot CLI

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -96,7 +96,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
           aws-region: eu-west-2
 
       - name: Checkout E2E tests
@@ -153,7 +153,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
           aws-region: eu-west-2
 
       - name: Checkout E2E tests
@@ -205,7 +205,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
           aws-region: eu-west-2
 
       - name: Checkout E2E tests

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     if: ${{ github.actor != 'dependabot[bot]' }}
     concurrency:
-      group: 'fsd-preaward-${{ inputs.environment }}-{{inputs.app_name}}'
+      group: 'fsd-preaward-${{ inputs.environment }}-${{inputs.app_name}}'
       cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -59,7 +59,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
       with:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-        role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+        role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
         aws-region: eu-west-2
 
     - name: Install AWS Copilot CLI


### PR DESCRIPTION
Fixes a small syntax error and typo in the `standard_deploy` workflow (neither of which were breaking errors but good to have the variables properly injected where needed).