### PR TITLE
Adding simple names to all jobs for readability

### DIFF
--- a/.github/workflows/determine-jobs.yml
+++ b/.github/workflows/determine-jobs.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
     determine-jobs-to-run:
+        name: Determine jobs to run
         runs-on: ubuntu-latest
         outputs: 
             jobs_to_run: ${{ steps.determine-jobs.outputs.job_list }}

--- a/.github/workflows/just-run-tests.yml
+++ b/.github/workflows/just-run-tests.yml
@@ -37,6 +37,7 @@ on:
 
 jobs:
   run_shared_tests_dev:
+    name: Run E2E tests (dev)
     if: ${{ always() && inputs.dev == true }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -53,6 +54,7 @@ jobs:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
 
   run_shared_tests_test:
+    name: Run E2E tests (test)
     if: ${{ always() && inputs.test == true }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -69,6 +71,7 @@ jobs:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
 
   run_shared_tests_uat:
+    name: Run E2E tests (uat)
     if: ${{ always() && inputs.uat == true }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:

--- a/.github/workflows/list-versions.yml
+++ b/.github/workflows/list-versions.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   list-versions:
+    name: List running versions
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout

--- a/.github/workflows/notify-slack-deployment-failed.yml
+++ b/.github/workflows/notify-slack-deployment-failed.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   notify_slack:
+    name: Slack failure notification
     runs-on: ubuntu-latest
     steps:
       - name: Check if deployment was manually rejected

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,8 +29,8 @@ env:
 
 jobs:
   paketo_build:
+    name: Package and build application
     runs-on: ubuntu-latest
-    name: Packaging and building the application
     outputs:
       image_location: ${{ steps.build_and_publish.outputs.image_location }}
     steps:

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -107,6 +107,7 @@ on:
 
 jobs:
   run_shared_tests_aws:
+    name: Run E2E tests
     concurrency: run_shared_tests_aws-${{ inputs.environment }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
@@ -124,6 +125,7 @@ jobs:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
 
   static_security_python:
+    name: Static security analysis (Bandit)
     if: ${{ inputs.run_static_security_python == true}}
     runs-on: ubuntu-latest
     environment: dev
@@ -151,6 +153,7 @@ jobs:
         run: uv run bandit --exclude */.venv/* -r . -lll
 
   zap-scan-aws:
+    name: Vulnerability scan (ZAP)
     if: inputs.app_name != '' && inputs.run_zap_scan == true
     runs-on: ubuntu-latest
     environment: test
@@ -163,6 +166,7 @@ jobs:
           artifact_name: zap-scan-${{ inputs.environment }}
 
   notify_slack:
+    name: Slack failure notification
     needs:
       - run_shared_tests_aws
       - static_security_python

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   testing-unit-postgres-aws:
+    name: Unit tests with Postgres
     runs-on: ubuntu-latest
     environment: Dev
     if: ${{ inputs.postgres_unit_testing == true }}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -74,6 +74,7 @@ on:
 
 jobs:
   run_application_e2e_test:
+    name: E2E tests for Apply
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -183,6 +184,7 @@ jobs:
           name: playwright-traces
           path: test-results/
   run_assessment_e2e_test:
+    name: E2E tests for Assess
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -238,6 +240,7 @@ jobs:
           path: ./funding-service-design-e2e-checks/results
           retention-days: 5
   run_performance_tests:
+    name: Performance tests
     runs-on: ubuntu-latest
     if: ${{ inputs.run_performance_tests == true}}
     defaults:

--- a/.github/workflows/standard-deploy.yml
+++ b/.github/workflows/standard-deploy.yml
@@ -37,6 +37,7 @@ on:
         required: false
 jobs:
   deploy:
+    name: Deploy to ${{ inputs.environment }}
     if: ${{ github.actor != 'dependabot[bot]' }}
     concurrency:
       group: 'fsd-preaward-${{ inputs.environment }}-${{inputs.app_name}}'
@@ -122,6 +123,7 @@ jobs:
         deployment_start_ts: ${{ steps.slack_start_deployment_message.outputs.timestamp }}
 
   notify_slack:
+    name: Slack failure notification
     needs:
       - deploy
     if: ${{ inputs.notify_slack && always() && needs.deploy.result == 'failure' }}

--- a/.github/workflows/update-preaward-env.yml
+++ b/.github/workflows/update-preaward-env.yml
@@ -20,6 +20,7 @@ on:
       
 jobs:
   copilot_environments_workflow_setup:
+    name: Setup Copilot environments
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.copilot_env_matrix.outputs.env_list }}
@@ -33,6 +34,7 @@ jobs:
           fi
 
   copilot_env_build:
+    name: Build and deploy to ${{ matrix.value }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout


### PR DESCRIPTION
For some GitHub workflow jobs we have nice, readable names like "Check DB migrations" while for others we don't have a name defined and so are forced to use whatever hyphenated label we've assigned to the job in the code e.g., `testing-unit-postgres-aws`.

This PR adds names to all jobs.

Example before:

![image](https://github.com/user-attachments/assets/9e458cf3-7177-4c3c-bc34-7fe023ba6189)

Example after:

![image](https://github.com/user-attachments/assets/89c5ed93-916c-457c-8b61-03fb524a3db8)
