### PR TITLE
FSPT-228: Update redirect status code

### DIFF
--- a/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
+++ b/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
@@ -27,6 +27,12 @@ Resources:
       - |
         function handler(event) {
           const host = event.request.headers.host.value;
+
+          // non-legacy domain pass through unchanged request
+          if (host.endsWith('.communities.gov.uk')) {
+            return event.request
+          }
+
           var qs=[];
             for (var key in event.request.querystring) {
                 if (event.request.querystring[key].multiValue) {
@@ -38,11 +44,6 @@ Resources:
 
           const parsedQueryString = qs.sort().join('&');
           const queryString = parsedQueryString ? "?" + parsedQueryString : '';
-
-          // non-legacy domain pass through unchanged request
-          if (host.endsWith('.communities.gov.uk')) {
-            return event.request
-          }
 
           const uri = event.request.uri;
           var newUrl;

--- a/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
+++ b/apps/pre-award/copilot/environments/addons/communities-redirect-cloudfront-function.yml
@@ -61,10 +61,10 @@ Resources:
             const serviceHostName = host.split('.')[0]
             newUrl = `https://${!serviceHostName}${DomainSuffix}${!uri}${!queryString}`
           }
-          // TODO: Switch to 301 when we are sure this is working as intended
+
           var response = {
-              statusCode: 302,
-              statusDescription: "Found",
+              statusCode: 301,
+              statusDescription: "Moved Permanently",
               headers: {
                   "location": {
                       value: newUrl,


### PR DESCRIPTION
Updates redirects to 301
(Now migration has been completed successfully we should return a 301 to update browsers, search engines etc permanently)

also moves query string logic after initial return statement to stop that code block being executed unnecessarily

