### PR TITLE
BAU: Include wildcard for artifacts

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -182,7 +182,7 @@ jobs:
         if: ${{ failure() }}
         with:
           name: playwright-traces
-          path: test-results/
+          path: test-results/*
   run_assessment_e2e_test:
     name: E2E tests for Assess
     runs-on: ubuntu-latest


### PR DESCRIPTION
Artifacts weren't found previously because they were in a sub-folder. This adds a wildcard so they should be found

e.g. https://github.com/communitiesuk/funding-service-pre-award/actions/runs/14039813318/job/39452192284#step:8:17
`Warning: No files were found with the provided path: test-results/. No artifacts will be uploaded.`