### PR TITLE
FLS-1271: enable shield protection on the cloudfront distribution

### DIFF
--- a/apps/pre-award/copilot/environments/overrides/cfn.patches.yml
+++ b/apps/pre-award/copilot/environments/overrides/cfn.patches.yml
@@ -19,3 +19,16 @@
   value: 
     - EventType: viewer-request 
       FunctionARN: !ImportValue CommunitiesRedirectArn
+
+- op: add
+  path: /Resources/ShieldAdvancedProtection
+  value:
+    Type: "AWS::Shield::Protection"
+    Properties:
+      Name: CloudFrontShieldProtection
+      ResourceArn: !Join
+      - ''
+      - - 'arn:aws:cloudfront::'
+        - !Ref 'AWS::AccountId'
+        - ':distribution/'
+        - !Ref CloudFrontDistribution


### PR DESCRIPTION
Enables Shield Advanced protection on the Cloudfront Distribution.

## How to test
I have tested this on Dev and confirmed it is enabled in the Shield Console