### PR TITLE
FLS-1309: Enable s3 Versioning 

### DIFF
--- a/apps/pre-award/copilot/environments/addons/form-uploads.yml
+++ b/apps/pre-award/copilot/environments/addons/form-uploads.yml
@@ -25,6 +25,8 @@ Resources:
     Properties:
       AccessControl: Private
       BucketName: !Sub fsd-form-uploads-${Env}
+      VersioningConfiguration:
+        Status: Enabled
       BucketEncryption:
         ServerSideEncryptionConfiguration:
         - ServerSideEncryptionByDefault:


### PR DESCRIPTION
[Ticket](https://mhclgdigital.atlassian.net/browse/FLS-1309)


We need to enable s3 versioning before replacing uploaded files, for the CHAM issue aftermath.