### PR TITLE
BAU: Only include runtime dependencies in package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: install dependencies
         if: ${{inputs.assets_required == true}}
-        run: uv sync
+        run: uv sync --no-dev
 
       - name: build static assets (if frontend)
         if: ${{inputs.assets_required == true}}
@@ -75,7 +75,7 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           
-          uv export --format requirements-txt --no-hashes > requirements.txt
+          uv export --no-dev --format requirements-txt --no-hashes > requirements.txt
 
           IMAGE_LOCATION="$IMAGE_ID:$VERSION"
 


### PR DESCRIPTION
Sister PR for same issue on `funding-service` repo: https://github.com/communitiesuk/funding-service/pull/540

Previously we were including all dependencies including test ones. This should speed up packaging and reduce security risks by only including runtime dependencies in the package.

Have tested this deploys successfully on dev https://github.com/communitiesuk/funding-service-pre-award/actions/runs/16519246903