### PR TITLE
Allow slack notifications to trigger from scheduled jobs

### DIFF
--- a/.github/workflows/notify-slack-deployment-failed.yml
+++ b/.github/workflows/notify-slack-deployment-failed.yml
@@ -83,8 +83,8 @@ jobs:
                     emoji: true
                     text: ":merged: View code changes"
                   url: ${{ inputs.compare_url }}
-      - name: Send message to Slack (workflow_dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' && steps.check-for-rejection.outputs.manually-rejected == 'false'  }}
+      - name: Send message to Slack (non-push)
+        if: ${{ github.event_name != 'push' && steps.check-for-rejection.outputs.manually-rejected == 'false'  }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           method: chat.postMessage


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-760

We're not sending slack notifications for failed deployments to the dev environment when the action runs on a schedule (eg every sunday night).