### PR TITLE
Revert "Use Python 3.13 for Playwright E2E tests to prevent dependency mismatch"

### DIFF
--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -170,7 +170,7 @@ jobs:
           enable-cache: true
       - name: Install playwright browsers
         # working-directory: funding-service-design-e2e-checks
-        run: uv run --python 3.13 playwright install --with-deps chromium
+        run: uv run --frozen playwright install --with-deps chromium
 
       - name: Run tests
         working-directory: ./funding-service-design-e2e-checks/tests


### PR DESCRIPTION
Reverts communitiesuk/funding-service-design-workflows#309

This was not a valid solution to the problem. This is: https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/1080