### PR TITLE
BAU- adding new job to our workflow pipeline

### DIFF
--- a/.github/workflows/cleanup-e2e-data.yml
+++ b/.github/workflows/cleanup-e2e-data.yml
@@ -43,13 +43,29 @@ jobs:
 
       - name: Cleanup E2E Test Data
         run: |
-          curl -X POST \
+          echo "Starting E2E test data cleanup..."
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}\nTIME_TOTAL:%{time_total}" \
+            -X POST \
             -u "${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}" \
             -H "User-Agent: github-actions" \
             -H "X-GitHub-Actions: cleanup-e2e" \
             -H "Content-Type: application/json" \
-            "https://apply.access-funding.${{ inputs.env_name || github.event.inputs.environment }}.communities.gov.uk/utils/e2e-test-data/cleanup" \
-            --fail-with-body && echo "✅ E2E cleanup completed successfully"
+            "https://apply.access-funding.${{ inputs.env_name || github.event.inputs.environment }}.communities.gov.uk/utils/e2e-test-data/cleanup")
+          
+          echo "Cleanup Response:"
+          echo "$response" | grep -v "HTTP_STATUS\|TIME_TOTAL"
+          
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | cut -d: -f2)
+          time_total=$(echo "$response" | grep "TIME_TOTAL" | cut -d: -f2)
+          
+          echo "Status: $http_status | Time: ${time_total}s"
+          
+          if [ "$http_status" -eq 200 ]; then
+            echo "E2E cleanup completed successfully"
+          else
+            echo "E2E cleanup failed with status $http_status"
+            exit 1
+          fi
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/cleanup-e2e-data.yml
+++ b/.github/workflows/cleanup-e2e-data.yml
@@ -1,0 +1,57 @@
+name: Cleanup E2E Test Data
+
+on:
+  workflow_call:
+    inputs:
+      env_name:
+        description: 'Environment to cleanup (E2E tests run in dev/test/uat)'
+        required: true
+        type: string
+    secrets:
+      AWS_ACCOUNT:
+        required: true
+      FS_BASIC_AUTH_USERNAME:
+        required: true
+      FS_BASIC_AUTH_PASSWORD:
+        required: true
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to cleanup (E2E tests run in dev/test/uat)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - test
+          - uat
+
+jobs:
+  cleanup-e2e-data:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: ${{ inputs.env_name || github.event.inputs.environment }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "cleanup_e2e_data_${{ inputs.env_name || github.event.inputs.environment }}"
+          aws-region: eu-west-2
+
+      - name: Cleanup E2E Test Data
+        run: |
+          curl -X POST \
+            -u "${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}" \
+            -H "User-Agent: github-actions" \
+            -H "X-GitHub-Actions: cleanup-e2e" \
+            -H "Content-Type: application/json" \
+            "https://apply.access-funding.${{ inputs.env_name || github.event.inputs.environment }}.communities.gov.uk/utils/cleanup-e2e-data" \
+            --fail-with-body && echo "✅ E2E cleanup completed successfully"
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "E2E cleanup failed. Check logs for details."

--- a/.github/workflows/cleanup-e2e-data.yml
+++ b/.github/workflows/cleanup-e2e-data.yml
@@ -48,7 +48,7 @@ jobs:
             -H "User-Agent: github-actions" \
             -H "X-GitHub-Actions: cleanup-e2e" \
             -H "Content-Type: application/json" \
-            "https://apply.access-funding.${{ inputs.env_name || github.event.inputs.environment }}.communities.gov.uk/utils/cleanup-e2e-data" \
+            "https://apply.access-funding.${{ inputs.env_name || github.event.inputs.environment }}.communities.gov.uk/utils/e2e-test-data/cleanup" \
             --fail-with-body && echo "✅ E2E cleanup completed successfully"
 
       - name: Notify on failure

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -266,7 +266,6 @@ jobs:
         id: unique_id
         run: |
           echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
-
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -290,6 +289,17 @@ jobs:
           name: performance-test-report-${{inputs.env_name}}-${{ steps.unique_id.outputs.unique_id }}
           path: ./funding-service-design-performance-tests/locust_html_report.html
           retention-days: 5
+  cleanup_e2e_data:
+    name: Cleanup E2E Test Data
+    if: ${{ always() && inputs.env_name == 'dev' }}
+    needs: [ run_application_e2e_test, run_python_e2e_test, run_assessment_e2e_test, run_performance_tests ]
+    uses: ./.github/workflows/cleanup-e2e-data.yml
+    with:
+      env_name: ${{ inputs.env_name }}
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
+      FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
 
 
 # Commented out as there aren't any shared accessibility tests

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -291,7 +291,7 @@ jobs:
           retention-days: 5
   cleanup_e2e_data:
     name: Cleanup E2E Test Data
-    if: ${{ always() && inputs.env_name == 'dev' }}
+    if: ${{ always() && (inputs.env_name == 'dev' || inputs.env_name == 'test' || inputs.env_name == 'uat') }}
     needs: [ run_application_e2e_test, run_python_e2e_test, run_assessment_e2e_test, run_performance_tests ]
     uses: ./.github/workflows/cleanup-e2e-data.yml
     with:


### PR DESCRIPTION
### Summary

This PR introduces an automated step to clean up E2E test data after E2E test runs. This prevents test data from accumulating in Test/UAT environments, which has been a major contributor to E2E flakiness and pipeline blockages.

#### Background

See this [ticket](https://mhclgdigital.atlassian.net/browse/FLS-1572) for more info

This PR adds a new GitHub Actions workflow to clean up E2E test data after running tests.

- The workflow is called cleanup-e2e-data.yml.
- It can be triggered manually or called from other workflows.
- Supports dev, test, and UAT environments.
- Uses a secure POST request to a /utils/cleanup-e2e-data endpoint with basic auth PR is [here](https://github.com/communitiesuk/funding-service-pre-award/pull/560) .
- Logs success or failure so we can monitor the cleanup.
- This ensures E2E test data does not pile up and keeps environments clean.