### PR TITLE
remove JS e2e tests

### DIFF
--- a/.github/workflows/just-run-tests.yml
+++ b/.github/workflows/just-run-tests.yml
@@ -19,17 +19,7 @@ on:
         default: false
         type: boolean
         description: Run performance tests
-      run_e2e_tests_application:
-        required: false
-        default: true
-        type: boolean
-        description: Run e2e tests (application)
-      run_e2e_tests_assessment:
-        required: false
-        default: true
-        type: boolean
-        description: Run e2e tests (assessment)
-      run_e2e_tests_python:
+      run_e2e_tests:
         required: false
         default: true
         type: boolean
@@ -42,9 +32,7 @@ jobs:
     uses: ./.github/workflows/run-shared-tests.yml
     with:
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
-      run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
-      run_e2e_tests_python: ${{inputs.run_e2e_tests_python}}
+      run_e2e_tests: ${{inputs.run_e2e_tests}}
       env_name: dev
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
@@ -59,9 +47,7 @@ jobs:
     uses: ./.github/workflows/run-shared-tests.yml
     with:
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
-      run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
-      run_e2e_tests_python: ${{inputs.run_e2e_tests_python}}
+      run_e2e_tests: ${{inputs.run_e2e_tests}}
       env_name: test
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
@@ -76,9 +62,7 @@ jobs:
     uses: ./.github/workflows/run-shared-tests.yml
     with:
       run_performance_tests: ${{inputs.run_performance_tests}}
-      run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
-      run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
-      run_e2e_tests_python: false  # these tests don't work in UAT env
+      run_e2e_tests: false  # these tests don't work in UAT env
       env_name: uat
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -18,14 +18,11 @@ on:
         required: false
         default: false
         type: boolean
-      run_e2e_tests_application:
+      run_e2e_tests:
         required: false
-        default: true
+        default: false
         type: boolean
-      run_e2e_tests_assessment:
-        required: false
-        default: true
-        type: boolean
+        description: Run e2e tests (python)
       run_static_security_python:
         required: false
         default: true
@@ -81,14 +78,11 @@ on:
         required: false
         default: false
         type: boolean
-      run_e2e_tests_application:
+      run_e2e_tests:
         required: false
         default: false
         type: boolean
-      run_e2e_tests_assessment:
-        required: false
-        default: false
-        type: boolean
+        description: Run e2e tests (python)
       run_static_security_python:
         required: false
         default: false
@@ -113,9 +107,7 @@ jobs:
     with:
       # run_performance_tests: ${{inputs.run_performance_tests}}
       run_performance_tests: false
-      run_e2e_tests_assessment: ${{inputs.run_e2e_tests_assessment}}
-      run_e2e_tests_application: ${{inputs.run_e2e_tests_application}}
-      run_e2e_tests_python: ${{ inputs.environment == 'dev' || inputs.environment == 'test' }}
+      run_e2e_tests: ${{ inputs.environment == 'dev' || inputs.environment == 'test' }}
       env_name: ${{inputs.environment}}
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -104,8 +104,8 @@ jobs:
         working-directory: ./funding-service-design-e2e-checks/tests
         run: uv run --frozen pytest --e2e-env ${{ inputs.env_name }} --tracing=retain-on-failure --browser chromium
         env:
-          E2E_DEVTEST_BASIC_AUTH_USERNAME: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
-          E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_PASSWORD }}
+          FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
+          FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
 
       - name: Upload E2E Test Report
         if: success() || failure()

--- a/.github/workflows/run-shared-tests.yml
+++ b/.github/workflows/run-shared-tests.yml
@@ -1,18 +1,6 @@
 on:
   workflow_call:
     inputs:
-      e2e_tests_target_url_frontend:
-        type: string
-        required:  false # TODO Make this true when all repos updated
-      e2e_tests_target_url_authenticator:
-        type: string
-        required:  false # TODO Make this true when all repos updated
-      e2e_tests_target_url_form_runner:
-        type: string
-        required:  false # TODO Make this true when all repos updated
-      e2e_tests_target_url_assessment:
-        type: string
-        required:  false # TODO Make this true when all repos updated
       perf_test_target_url_application_store:
         type: string
         required: false
@@ -38,15 +26,7 @@ on:
         required: false
         default: false
         type: boolean
-      run_e2e_tests_application:
-        required: false
-        default: true
-        type: boolean
-      run_e2e_tests_assessment:
-        required: false
-        default: true
-        type: boolean
-      run_e2e_tests_python:
+      run_e2e_tests:
         required: false
         default: true
         type: boolean
@@ -73,13 +53,14 @@ on:
         required: true
 
 jobs:
-  run_application_e2e_test:
-    name: E2E tests for Apply
+  run_e2e_test:
+    name: E2E tests (Apply and Assess)
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
     environment: ${{ inputs.env_name }}
-    if: ${{ inputs.run_e2e_tests_application == true}}
+    if: ${{ inputs.run_e2e_tests == true}}
     defaults:
       run:
         working-directory: ./funding-service-design-e2e-checks
@@ -111,59 +92,6 @@ jobs:
         id: unique_id
         run: |
           echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
-
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
-        with:
-          node-version: 21
-      - name: Install dependencies
-        run: npm ci
-      - name: Run E2E Tests Application For All Funds
-        run: npx wdio run ./wdio.conf_headless.js
-        env:
-          EXCLUDE_ASSESSMENT: true
-          EXCLUDE_APPLICATION: false
-          E2E_TEST_ENVIRONMENT: ${{ inputs.env_name }}
-      - name: Upload E2E Test Report Application
-        if: success() || failure()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
-        with:
-          name: e2e-test-report-application-${{inputs.env_name}}-${{ steps.unique_id.outputs.unique_id }}
-          path: ./funding-service-design-e2e-checks/results
-          retention-days: 5
-  run_python_e2e_test:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read  # This is required for actions/checkout
-    environment: ${{ inputs.env_name }}
-    if: ${{ inputs.run_e2e_tests_python == true}}
-    defaults:
-      run:
-        working-directory: ./funding-service-design-e2e-checks
-    steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-        with:
-          app-id: ${{ secrets.FSD_GH_APP_ID }}
-          private-key: ${{ secrets.FSD_GH_APP_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: "funding-service-design-e2e-checks"
-
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
-          aws-region: eu-west-2
-
-      - name: Checkout E2E tests
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: communitiesuk/funding-service-design-e2e-checks
-          path: ./funding-service-design-e2e-checks
-          token: ${{ steps.generate_token.outputs.token }}
-      
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5
         with:
@@ -172,67 +100,14 @@ jobs:
         # working-directory: funding-service-design-e2e-checks
         run: uv run --frozen playwright install --with-deps chromium
 
-      - name: Run tests
+      - name: Run Python E2E tests
         working-directory: ./funding-service-design-e2e-checks/tests
         run: uv run --frozen pytest --e2e-env ${{ inputs.env_name }} --tracing=retain-on-failure --browser chromium
         env:
           E2E_DEVTEST_BASIC_AUTH_USERNAME: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
-          E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_USERNAME }}
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
-        if: ${{ failure() }}
-        with:
-          name: playwright-traces
-          path: test-results/*
-  run_assessment_e2e_test:
-    name: E2E tests for Assess
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-    environment: ${{ inputs.env_name }}
-    if: ${{ inputs.run_e2e_tests_assessment == true}}
-    defaults:
-      run:
-        working-directory: ./funding-service-design-e2e-checks
-    steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-        with:
-          app-id: ${{ secrets.FSD_GH_APP_ID }}
-          private-key: ${{ secrets.FSD_GH_APP_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: "funding-service-design-e2e-checks"
+          E2E_DEVTEST_BASIC_AUTH_PASSWORD: ${{ secrets.E2E_DEVTEST_BASIC_AUTH_PASSWORD }}
 
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
-          aws-region: eu-west-2
-
-      - name: Checkout E2E tests
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: communitiesuk/funding-service-design-e2e-checks
-          path: ./funding-service-design-e2e-checks
-          token: ${{ steps.generate_token.outputs.token }}
-      - name: 'Set unique id'
-        id: unique_id
-        run: |
-          echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
-
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
-        with:
-          node-version: 21
-      - name: Install dependencies
-        run: npm ci
-      - name: Run E2E Tests Assessment For All Funds
-        run:  npx wdio run wdio.conf_headless.js
-        env:
-          EXCLUDE_ASSESSMENT: false
-          EXCLUDE_APPLICATION: true
-          E2E_TEST_ENVIRONMENT: ${{ inputs.env_name }}
-      - name: Upload Assessment E2E Test Report
+      - name: Upload E2E Test Report
         if: success() || failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
@@ -292,7 +167,7 @@ jobs:
   cleanup_e2e_data:
     name: Cleanup E2E Test Data
     if: ${{ always() && (inputs.env_name == 'dev' || inputs.env_name == 'test' || inputs.env_name == 'uat') }}
-    needs: [ run_application_e2e_test, run_python_e2e_test, run_assessment_e2e_test, run_performance_tests ]
+    needs: [ run_e2e_test, run_performance_tests ]
     uses: ./.github/workflows/cleanup-e2e-data.yml
     with:
       env_name: ${{ inputs.env_name }}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-1639

This PR removes JavaScript/WebDriverIO E2E tests from the shared workflow and replaces them with a single Python Playwright E2E test job that covers both Apply and Assess journeys.

### Background
Previously, the shared workflow ran three separate E2E test jobs:

- #### JavaScript Apply tests (run_application_e2e_test) - Tested COF R4W2 using WebDriverIO
- #### JavaScript Assess tests (run_assessment_e2e_test) - Tested COF R4W2 using WebDriverIO
- #### Python tests (run_python_e2e_test) - Tested CTDF R1 using Playwright

The JavaScript tests were slow, complex, and redundant. The new Python Playwright tests in funding-service-design-e2e-checks now cover the complete end-to-end journey (Apply → Assess) using the optimised CTDF R2 dummy fund. There's a [PR](https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/1093) which removed js e2e test from funding-service-design-e2e-checks.

### Testing

I've tested this branch by making some changes in pre-award, PR is [here](https://github.com/communitiesuk/funding-service-pre-award/pull/592) and used this workflow branch to test the changes. Then I deployed to dev [here's the pipeline](https://github.com/communitiesuk/funding-service-pre-award/actions/runs/20657636517).


### Next Steps:

Test all PRs together - Deploy pre-award to dev/test with branch references

- ✅ Verify E2E tests pass - Confirm Python tests work end-to-end ( Done ✅ )
- ✅ Merge workflows [PR](https://github.com/communitiesuk/funding-service-design-workflows/pull/314)
- ✅ Merge e2e-checks [PR](https://github.com/communitiesuk/funding-service-design-e2e-checks/pull/1093)
- ✅ Update pre-award PR - Change **@remove-js-e2e-tests** to **@main**
- ✅ Merge pre-award [PR](https://github.com/communitiesuk/funding-service-pre-award/pull/592)
