### PR TITLE
BAU: Set list of options for workflow dispatch

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -91,9 +91,13 @@ on:
         required: false
         type: string
       environment:
+        type: choice
         required: true
-        type: string
-        default: dev
+        options:
+          - dev
+          - test
+          - uat
+          - prod
       run_zap_scan:
         required: false
         default: false


### PR DESCRIPTION
Closes a bug where workflow dispatch environment wasn't the set list of accepted environments.